### PR TITLE
Add CI, repo hygiene tooling, game-logic module, app refactor, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: basic-ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Validate question data
+        run: node scripts/validate-questions.mjs
+      - name: Syntax check JS
+        run: npm run check:js
+      - name: Run unit tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Dependencies
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS / editor noise
+.DS_Store
+.vscode/
+.idea/
+
+# Build artifacts
+coverage/
+dist/
+
+# Env files
+.env
+.env.*
+!.env.example

--- a/BRANCH_CLEANUP_PLAN.md
+++ b/BRANCH_CLEANUP_PLAN.md
@@ -1,0 +1,112 @@
+# Jeopardish Branch Cleanup + Production MVP Plan
+
+## 1) Current Git Reality (as of 2026-04-03)
+
+- Local branches available in this checkout: `work` only.
+- No git remotes are currently configured in this local clone.
+- Historic branch names can still be inferred from merge commit history.
+
+### Historical branches seen in merge history
+
+- `mobile-first-overhaul` (latest major UI update)
+- `github-pages`, `gh-pages` (deployment-oriented)
+- `alex-1`, `updates`, `newupdates`, `newnewnewnewnewnew`, `test`
+- `dependabot/npm_and_yarn/multi-d54dc5d3e6`
+- `master`
+
+---
+
+## 2) What to merge vs. retire
+
+### Keep / preserve intent from
+
+1. **`mobile-first-overhaul`**
+   - Treat this as the baseline for your MVP UI/UX polish.
+2. **Dependabot branch changes**
+   - Keep dependency/security updates, but re-validate versions today.
+3. **`github-pages` / `gh-pages`**
+   - Keep only if GitHub Pages deployment is still part of your release path.
+
+### Retire / archive candidates
+
+- `test`, `newnewnewnewnewnew`, `newupdates`, and any one-off experiment branches.
+- Duplicate deployment branches (`gh-pages` vs `github-pages`) — keep one naming convention.
+- Any branch that has no unique commits compared to your production base.
+
+---
+
+## 3) Branch triage workflow (run when remote is configured)
+
+```bash
+# 0) connect remote if missing
+# git remote add origin <repo-url>
+
+git fetch --all --prune
+
+# 1) list active + stale branches
+git branch -a
+git for-each-ref --sort=-committerdate refs/remotes --format='%(committerdate:short) %(refname:short) %(authorname) %(subject)'
+
+# 2) find merged branches
+git checkout main  # or master, whichever is the production base
+git branch -r --merged
+
+# 3) find unmerged branches
+git branch -r --no-merged
+
+# 4) compare each unmerged branch before deciding
+# git log --oneline origin/main..origin/<branch>
+# git diff --stat origin/main...origin/<branch>
+```
+
+Decision rubric:
+- **Merge** if it improves UX, stability, accessibility, performance, or deploy reliability.
+- **Cherry-pick** if only some commits are useful.
+- **Close/delete** if obsolete, duplicated, or unreviewable.
+
+---
+
+## 4) Codebase cleanup priorities for a production-quality MVP
+
+1. **Stop tracking dependency vendor files in git**
+   - Keep `node_modules/` ignored (now handled via `.gitignore`).
+2. **Consolidate legacy artifacts**
+   - `backups/` and duplicate asset files should move to either:
+     - `archive/` (not shipped), or
+     - be removed after verifying no references.
+3. **Standardize project layout**
+   - Suggested structure:
+     - `src/` for app logic
+     - `public/` for static assets
+     - `docs/` for plans/specs
+4. **Add quality gates**
+   - lint + format + basic CI checks on PRs.
+5. **Define MVP quality bar**
+   - mobile-first responsive pass
+   - keyboard accessibility
+   - Lighthouse performance + accessibility thresholds
+
+---
+
+## 5) Recommended immediate next actions
+
+1. Configure `origin` remote in this clone.
+2. Run the triage workflow above and create three lists:
+   - **merge now**
+   - **cherry-pick later**
+   - **delete/archive**
+3. Open one "MVP hardening" branch for:
+   - file structure cleanup
+   - dependency refresh
+   - accessibility/performance pass
+4. Freeze ad-hoc branches and enforce PR naming/review rules.
+
+---
+
+## 6) Suggested branch policy going forward
+
+- `main` = production-ready only.
+- `develop` (optional) = integration branch.
+- `feature/<ticket>-<slug>` for all new work.
+- Auto-delete branch after merge.
+- Require passing checks + at least one review.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,41 @@ Jeopardish can provide that same comforting presence to future potential contest
 Users can practice for the show using the simple click of a button to randomly generate question/answer pairs from a database of questions from old episodes, like flash cards to help learn random facts from a plethora of historical categories from the show.
 
 
+
+## Repo Operations (Production MVP Hardening)
+
+This repo now includes lightweight operations scripts so you can execute the branch-cleanup plan immediately:
+
+- Generate a branch triage report:
+
+  ```bash
+  npm run triage:branches
+  # or set base branch explicitly
+  bash scripts/branch-triage-report.sh master
+  ```
+
+- Validate local trivia dataset integrity:
+
+  ```bash
+  npm run validate:questions
+  ```
+
+- Check JavaScript syntax:
+
+  ```bash
+  npm run check:js
+  ```
+
+- Run unit tests for answer matching logic:
+
+  ```bash
+  npm test
+  ```
+
+Use `docs/BRANCH_DECISIONS_TEMPLATE.md` to capture merge/cherry-pick/delete decisions after each report run.
+
+Latest filled decision pass: `docs/BRANCH_DECISIONS_2026-04-05.md`.
+
 ## API and Data Sample
 
 ![Jservice](http://www.jService.io)

--- a/app.js
+++ b/app.js
@@ -1,254 +1,282 @@
-const apiUrl = 'https://cors-anywhere.herokuapp.com/https://cluebase.lukelav.in/clues/random';
+'use strict';
 
-// Create buttons for basic functionality & user interaction
-const checkButton = document.getElementById('checkButton');
-const answerButton = document.getElementById('answerButton');
-const questionButton = document.getElementById('questionButton');
+const QUESTION_SOURCE = './questions/jeopardy-questions.json';
+const FETCH_TIMEOUT_MS = 10000;
 
-// Create userInput box for entering answer
-const userInput = document.getElementById('inputbox');
-
-// Use separate boxes to distribute data within word-bubble
-const categoryBox = document.getElementById('categoryBox');
-const questionBox = document.getElementById('questionBox');
-const answerBox = document.getElementById('answerBox');
-const dataBox = document.getElementById('dataBox');
-
-// Initialize variables to store data to display
-let currentStreak = 0;
-let bestStreak = 0;
-let score = 0;
-
-// Error messages
 const jeopardyErrors = [
-    {
-        category: "TECHNICAL DIFFICULTIES",
-        question: "This term describes what happens when your app can't load the local question database.",
-        answer: "What is 'a file reading error'?",
-        value: "$0"
-    },
-    {
-        category: "OOOPS!",
-        question: "This famous line was uttered by every programmer ever when their code didn't work as expected.",
-        answer: "What is 'It works on my machine'?",
-        value: "$0"
-    },
-    {
-        category: "MYSTERY OF CODING",
-        question: "It's the spooky thing that happens when your API call goes into the void and never returns.",
-        answer: "What is 'the ghost in the machine'?",
-        value: "$0"
-    },
-    {
-        category: "SOFTWARE SNAFUS",
-        question: "This phrase is often said when an application stops working right as you show it to someone.",
-        answer: "What is 'demo demon'?",
-        value: "$0"
-    }
+  {
+    category: 'TECHNICAL DIFFICULTIES',
+    question: "This term describes what happens when your app can't load the local question database.",
+    answer: "What is 'a file reading error'?",
+    value: '$0',
+  },
+  {
+    category: 'OOOPS!',
+    question: "This famous line was uttered by every programmer ever when their code didn't work as expected.",
+    answer: "What is 'It works on my machine'?",
+    value: '$0',
+  },
+  {
+    category: 'MYSTERY OF CODING',
+    question: "It's the spooky thing that happens when your API call goes into the void and never returns.",
+    answer: "What is 'the ghost in the machine'?",
+    value: '$0',
+  },
+  {
+    category: 'SOFTWARE SNAFUS',
+    question: 'This phrase is often said when an application stops working right as you show it to someone.',
+    answer: "What is 'demo demon'?",
+    value: '$0',
+  },
 ];
 
-// Introduce the game via console
-console.log(`Welcome to Jeopardish!!!`);
-console.log(`Click the "new question" button to get a random Jeopardy-style question & test your knowledge.`);
-console.log(`Multiple correct answers in a row will start a streak...`);
-console.log(`...but get one wrong & the streak will reset.`);
-console.log("Let's see how many correct answers you can string together! ");
-console.log(`Streak is currently at ` + currentStreak);
-console.log("HAVE FUN YA MANIAC!");
+const state = {
+  questions: [],
+  currentClue: null,
+  currentStreak: 0,
+  bestStreak: 0,
+  score: 0,
+  lastClueIndex: -1,
+  currentClueValue: 100,
+};
 
-// Load questions from local JSON file
-let questions = [];
+const dom = {};
+const BEST_STREAK_KEY = 'jeopardish.bestStreak';
 
-fetch('./questions/questions.json')
-    .then(response => {
-        console.log('Fetch response:', response); // Log the response
-        return response.json();
-    })
-    .then(data => {
-        questions = data;
-        console.log('Questions loaded:', questions.length);
-        getNewQuestion(); // Load the first question after fetching
-    })
-    .catch(error => {
-        console.error('Error loading questions:', error);
-        displayErrorMessage("Failed to load questions. Please try again later.");
-    });
-
-// Function to get a random question
-function getRandomQuestion() {
-    return questions[Math.floor(Math.random() * questions.length)];
+const logic = globalThis.JeopardishLogic || null;
+if (!logic) {
+  throw new Error('JeopardishLogic failed to load. Ensure game-logic.js is included before app.js.');
 }
 
-// Function to display error messages in the UI
+function setText(el, text) {
+  el.textContent = text;
+}
+
+function loadPersistedBestStreak() {
+  try {
+    const value = globalThis.localStorage?.getItem(BEST_STREAK_KEY);
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      state.bestStreak = parsed;
+    }
+  } catch (error) {
+    console.warn('Unable to read persisted best streak.', error);
+  }
+}
+
+function persistBestStreak() {
+  try {
+    globalThis.localStorage?.setItem(BEST_STREAK_KEY, String(state.bestStreak));
+  } catch (error) {
+    console.warn('Unable to persist best streak.', error);
+  }
+}
+
+function setStatus(message) {
+  setText(dom.statusMessage, message || '');
+}
+
+function setControlsEnabled(enabled) {
+  dom.checkButton.disabled = !enabled;
+  dom.answerButton.disabled = !enabled;
+}
+
+function setCategory(category, value) {
+  dom.categoryBox.textContent = '';
+
+  const categoryLine = document.createElement('strong');
+  categoryLine.textContent = category;
+
+  const valueLine = document.createElement('span');
+  valueLine.textContent = ` for ${value}`;
+
+  dom.categoryBox.append(categoryLine, valueLine);
+}
+
+function toggleAnswer(show) {
+  dom.answerBox.style.display = show ? 'flex' : 'none';
+}
+
+function renderScoreboard() {
+  setText(dom.currentStreak, `Current Streak: ${state.currentStreak}`);
+  setText(dom.bestStreak, `Best Streak: ${state.bestStreak}`);
+  setText(dom.score, `Score: $${state.score}`);
+}
+
 function displayErrorMessage(message) {
-    categoryBox.innerHTML = "Error";
-    questionBox.innerHTML = message;
-    answerBox.innerHTML = "";
-    answerBox.style.display = "block";
+  setStatus(message);
+  setText(dom.categoryBox, 'Error');
+  setText(dom.questionBox, message);
+  setText(dom.answerBox, '');
+  toggleAnswer(true);
 }
 
-// Update getNewQuestion function
-const getNewQuestion = () => {
-    try {
-        const clue = getRandomQuestion();
-        // Clear previous content
-        categoryBox.innerHTML = '';
-        questionBox.innerHTML = '';
-        answerBox.innerHTML = '';
-        userInput.value = '';
-
-        if (clue) {
-            // Display in word bubble
-            categoryBox.innerHTML = clue.category.toUpperCase() + '<br/> for ' + clue.value;
-            questionBox.innerHTML = clue.question;
-            answerBox.innerHTML = clue.answer;
-            answerBox.style.display = 'none';
-        } else {
-            throw new Error("No clues available");
-        }
-    } catch (error) {
-        console.error('Failed to fetch clue:', error);
-        displayErrorJoke();
-    }
-};
-
-// Function to display a random error joke
-const displayErrorJoke = () => {
-    let randomError = jeopardyErrors[Math.floor(Math.random() * jeopardyErrors.length)];
-    categoryBox.innerHTML = randomError.category + '<br/> for ' + randomError.value;
-    questionBox.innerHTML = randomError.question;
-    answerBox.innerHTML = randomError.answer;
-    answerBox.style.display = 'block';
-};
-
-// Reveal or hide answer
-const showHideAnswer = () => {
-    answerBox.style.display = answerBox.style.display === "none" ? "flex" : "none";
-};
-
-// Check answer function
-const checkAnswer = () => {
-    if (!answerBox.innerHTML.trim()) {
-        displayErrorMessage('No answer available. Has a question been loaded?');
-        return;
-    }
-
-    let correctAnswer = cleanAnswer(answerBox.innerHTML.trim());
-    let userAnswerCleaned = cleanAnswer(userInput.value);
-
-    if (!userAnswerCleaned) {
-        displayErrorMessage('User input is empty');
-        return;
-    }
-
-    if (compareAnswers(userAnswerCleaned, correctAnswer)) {
-        currentStreak++;
-        score += 100;
-        if (currentStreak > bestStreak) {
-            bestStreak = currentStreak;
-        }
-        displayCorrectAnswerMessage();
-    } else {
-        currentStreak = 0;
-        score = 0;
-        displayIncorrectAnswerMessage(correctAnswer);
-    }
-
-    updateScoreBoard();
-    userInput.value = '';
-};
-
-// Function to display correct answer message
-const displayCorrectAnswerMessage = () => {
-    categoryBox.innerHTML = "";
-    questionBox.innerHTML = "Correct! Your streak is now: " + currentStreak;
-    answerBox.style.display = "flex";
-    answerBox.innerHTML = "Correct answer streak is now " + currentStreak;
-};
-
-// Function to display incorrect answer message
-const displayIncorrectAnswerMessage = (correctAnswer) => {
-    categoryBox.innerHTML = "";
-    questionBox.innerHTML = "Incorrect! The correct answer was: " + correctAnswer;
-    answerBox.style.display = "flex";
-    answerBox.innerHTML = `STREAK RESET!`;
-};
-
-// Function to clean up and standardize answers for comparison
-const cleanAnswer = (answer) => {
-    return answer.toLowerCase()
-        .replace(/^(what|who|where|when) (is|are|was|were) /i, '')
-        .replace(/[^a-z0-9]/g, '')
-        .trim();
-};
-
-// Function to compare user's answer with the correct answer
-const compareAnswers = (userAnswer, correctAnswer) => {
-    // Check if the user's answer is contained within the correct answer or vice versa
-    if (correctAnswer.includes(userAnswer) || userAnswer.includes(correctAnswer)) {
-        return true;
-    }
-    const levenshteinDistance = getLevenshteinDistance(userAnswer, correctAnswer);
-    return levenshteinDistance <= Math.min(3, Math.floor(correctAnswer.length / 2));
-};
-
-// Levenshtein distance algorithm
-const getLevenshteinDistance = (a, b) => {
-    const matrix = [];
-    let i, j;
-    if (a.length === 0) return b.length;
-    if (b.length === 0) return a.length;
-
-    for (i = 0; i <= b.length; i++) {
-        matrix[i] = [i];
-    }
-    for (j = 0; j <= a.length; j++) {
-        matrix[0][j] = j;
-    }
-
-    for (i = 1; i <= b.length; i++) {
-        for (j = 1; j <= a.length; j++) {
-            if (b.charAt(i - 1) === a.charAt(j - 1)) {
-                matrix[i][j] = matrix[i - 1][j - 1];
-            } else {
-                matrix[i][j] = Math.min(matrix[i - 1][j - 1] + 1, Math.min(matrix[i][j - 1] + 1, matrix[i - 1][j] + 1));
-            }
-        }
-    }
-    return matrix[b.length][a.length];
-};
-
-// Update scoreboard
-function updateScoreBoard() {
-    dataBox.innerHTML = `
-        <p id="currentStreak">Current Streak: ${currentStreak}</p>
-        <p id="bestStreak">Best Streak: ${bestStreak}</p>
-        <p id="score">Score: $${score}</p>
-    `;
+function displayErrorJoke() {
+  const randomError = jeopardyErrors[Math.floor(Math.random() * jeopardyErrors.length)];
+  setStatus('There was a problem loading a normal clue. Showing fallback clue.');
+  setCategory(randomError.category, randomError.value);
+  setText(dom.questionBox, randomError.question);
+  setText(dom.answerBox, randomError.answer);
+  toggleAnswer(true);
+  setControlsEnabled(true);
 }
 
-// Wrap event listeners and initial question load in DOMContentLoaded event
-document.addEventListener('DOMContentLoaded', () => {
-    console.log('DOM fully loaded and parsed');
+function getRandomQuestion() {
+  if (state.questions.length === 0) return null;
 
-    const hamburgerMenu = document.getElementById('hamburgerMenu');
-    const navMenu = document.getElementById('navMenu');
+  let idx = Math.floor(Math.random() * state.questions.length);
+  if (state.questions.length > 1 && idx === state.lastClueIndex) {
+    idx = (idx + 1) % state.questions.length;
+  }
+  state.lastClueIndex = idx;
+  return state.questions[idx] ?? null;
+}
 
-    hamburgerMenu.addEventListener('click', () => {
-        navMenu.classList.toggle('active');
-    });
-    
-    // Attach event listeners
-    answerButton.addEventListener('click', showHideAnswer);
-    questionButton.addEventListener('click', getNewQuestion);
-    checkButton.addEventListener('click', checkAnswer);
-    
-    userInput.addEventListener("keydown", (event) => {
-        if (event.key === "Enter") {
-            checkAnswer();
-        }
-    });
-    
-    // Initial question load
+function renderClue(clue) {
+  if (!clue) {
+    displayErrorJoke();
+    return;
+  }
+
+  state.currentClue = clue;
+  state.currentClueValue = logic.parseClueValue(clue.value, 100);
+  setCategory(
+    String(clue.category || 'Unknown Category').toUpperCase(),
+    `$${state.currentClueValue}`,
+  );
+  setText(dom.questionBox, clue.question || 'No question available.');
+  setText(dom.answerBox, clue.answer || 'No answer available.');
+  setStatus('New clue loaded. Enter your answer and press Check Answer.');
+  toggleAnswer(false);
+  setControlsEnabled(true);
+  dom.userInput.value = '';
+  dom.userInput.focus();
+}
+
+function getNewQuestion() {
+  renderClue(getRandomQuestion());
+}
+
+function displayCorrectAnswerMessage() {
+  setText(dom.categoryBox, '');
+  setText(dom.questionBox, `Correct! Your streak is now: ${state.currentStreak}`);
+  setText(dom.answerBox, `Correct answer streak is now ${state.currentStreak}`);
+  toggleAnswer(true);
+}
+
+function displayIncorrectAnswerMessage(correctAnswer) {
+  setText(dom.categoryBox, '');
+  setText(dom.questionBox, `Incorrect! The correct answer was: ${correctAnswer}`);
+  setText(dom.answerBox, 'STREAK RESET!');
+  setStatus('Incorrect. Load a new clue to continue.');
+  toggleAnswer(true);
+}
+
+function checkAnswer() {
+  if (!state.currentClue) {
+    displayErrorMessage('No question available yet. Please load one first.');
+    return;
+  }
+
+  const userAnswerCleaned = logic.cleanAnswer(dom.userInput.value);
+  const correctAnswer = logic.cleanAnswer(state.currentClue.answer || '');
+
+  if (!userAnswerCleaned) {
+    displayErrorMessage('Please enter an answer before checking.');
+    return;
+  }
+
+  if (logic.compareAnswers(userAnswerCleaned, correctAnswer)) {
+    state.currentStreak += 1;
+    state.score += state.currentClueValue;
+    state.bestStreak = Math.max(state.bestStreak, state.currentStreak);
+    persistBestStreak();
+    displayCorrectAnswerMessage();
+    setStatus(`Correct. +$${state.currentClueValue}. Load a new clue to continue your streak.`);
+  } else {
+    state.currentStreak = 0;
+    state.score = 0;
+    displayIncorrectAnswerMessage(correctAnswer || 'Unknown');
+  }
+
+  state.currentClue = null;
+  setControlsEnabled(false);
+  renderScoreboard();
+  dom.userInput.value = '';
+}
+
+function showHideAnswer() {
+  toggleAnswer(dom.answerBox.style.display === 'none');
+}
+
+async function loadQuestions() {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    setControlsEnabled(false);
+    setStatus('Loading question bank…');
+    setText(dom.questionBox, 'Loading questions...');
+    const response = await fetch(QUESTION_SOURCE, { signal: abort.signal });
+    if (!response.ok) {
+      throw new Error(`Failed to load questions: ${response.status}`);
+    }
+
+    const data = await response.json();
+    if (!Array.isArray(data) || data.length === 0) {
+      throw new Error('Question dataset is empty or invalid.');
+    }
+
+    state.questions = data;
+    setStatus(`Loaded ${data.length.toLocaleString()} clues.`);
     getNewQuestion();
+  } catch (error) {
+    console.error('Error loading questions:', error);
+    displayErrorJoke();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function bindDom() {
+  dom.checkButton = document.getElementById('checkButton');
+  dom.answerButton = document.getElementById('answerButton');
+  dom.questionButton = document.getElementById('questionButton');
+  dom.userInput = document.getElementById('inputbox');
+  dom.categoryBox = document.getElementById('categoryBox');
+  dom.statusMessage = document.getElementById('statusMessage');
+  dom.questionBox = document.getElementById('questionBox');
+  dom.answerBox = document.getElementById('answerBox');
+  dom.currentStreak = document.getElementById('currentStreak');
+  dom.bestStreak = document.getElementById('bestStreak');
+  dom.score = document.getElementById('score');
+  dom.hamburgerMenu = document.getElementById('hamburgerMenu');
+  dom.navMenu = document.getElementById('navMenu');
+}
+
+function bindEvents() {
+  dom.hamburgerMenu.addEventListener('click', () => {
+    dom.navMenu.classList.toggle('active');
+  });
+
+  dom.answerButton.addEventListener('click', showHideAnswer);
+  dom.questionButton.addEventListener('click', getNewQuestion);
+  dom.checkButton.addEventListener('click', checkAnswer);
+  dom.userInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      checkAnswer();
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  loadPersistedBestStreak();
+  bindDom();
+  bindEvents();
+  setControlsEnabled(false);
+  setStatus('Initializing game…');
+  renderScoreboard();
+
+  console.log('Welcome to Jeopardish!');
+  await loadQuestions();
 });

--- a/docs/BRANCH_DECISIONS_2026-04-05.md
+++ b/docs/BRANCH_DECISIONS_2026-04-05.md
@@ -1,0 +1,82 @@
+# Branch Decisions — 2026-04-05
+
+## Snapshot Metadata
+
+- Date: 2026-04-05 (UTC)
+- Reviewer: Codex + repo owner
+- Base branch used for triage: `work`
+- Triage report: `reports/branch-triage-2026-04-05.md`
+- Repo reality in this clone: **no remote configured**, so merge/delete actions are currently recommendations until `origin` is attached.
+
+## Decision Summary (from historical merge metadata)
+
+### Merge now (if still unmerged in remote)
+
+1. `mobile-first-overhaul`
+   - reason: latest UI modernization branch, likely closest to current MVP UX baseline.
+   - risk: medium (verify responsiveness regressions and asset references).
+   - owner: product/frontend.
+
+2. `dependabot/npm_and_yarn/multi-d54dc5d3e6`
+   - reason: dependency/security update stream should be retained if not superseded.
+   - risk: low/medium (run smoke tests + CI).
+   - owner: maintainer.
+
+### Cherry-pick later
+
+1. `github-pages` / `gh-pages`
+   - reason: deployment-oriented changes may still be useful, but keep one canonical deployment path.
+   - action: cherry-pick only deploy pipeline/static hosting commits you still need.
+   - owner: maintainer/devops.
+
+2. `alex-1`
+   - reason: likely mixed feature/experiment commits.
+   - action: cherry-pick specific production-safe commits after review.
+   - owner: maintainer.
+
+### Archive / delete (after remote verification)
+
+1. `test`
+   - reason: exploratory branch naming, low long-term value.
+2. `newupdates`
+   - reason: non-descriptive and likely superseded.
+3. `newnewnewnewnewnew`
+   - reason: experimental branch, poor traceability.
+4. duplicate deployment branch (`gh-pages` or `github-pages`)
+   - reason: keep one naming convention only.
+
+## Required Verification Before Deleting Any Branch
+
+Run these once `origin` is configured:
+
+```bash
+git remote add origin <repo-url>        # if missing
+git fetch --all --prune
+
+# verify branches with unique commits
+for b in mobile-first-overhaul dependabot/npm_and_yarn/multi-d54dc5d3e6 github-pages gh-pages alex-1 test newupdates newnewnewnewnewnew; do
+  echo "=== $b ==="
+  git log --oneline origin/work..origin/$b | head -n 20 || true
+  git diff --stat origin/work...origin/$b | head -n 20 || true
+done
+```
+
+Delete only branches with zero required unique commits:
+
+```bash
+git push origin --delete <branch>
+```
+
+## Production MVP Hardening Queue (next 3 PRs)
+
+1. **PR 1: repo hygiene + structure**
+   - move archival artifacts under `archive/`
+   - remove dead duplicate assets not referenced by runtime files.
+
+2. **PR 2: UX polish + accessibility**
+   - keyboard navigation review, focus states, contrast checks.
+
+3. **PR 3: release readiness**
+   - lock CI required checks
+   - tag MVP release
+   - branch protection + auto-delete merged branches.

--- a/docs/BRANCH_DECISIONS_TEMPLATE.md
+++ b/docs/BRANCH_DECISIONS_TEMPLATE.md
@@ -1,0 +1,41 @@
+# Branch Decisions (Template)
+
+Use this after generating a report via:
+
+```bash
+scripts/branch-triage-report.sh main
+# or
+scripts/branch-triage-report.sh master
+```
+
+## Snapshot Metadata
+
+- Date:
+- Reviewer:
+- Base branch:
+- Report file:
+
+## Merge now
+
+- branch:
+  - reason:
+  - risk:
+  - owner:
+
+## Cherry-pick later
+
+- branch:
+  - commit(s):
+  - reason:
+  - owner:
+
+## Archive / delete
+
+- branch:
+  - reason:
+
+## Follow-up tasks
+
+- [ ] Remove stale remote branches after merge.
+- [ ] Ensure branch protection and required checks are enabled.
+- [ ] Add release tag for MVP checkpoint.

--- a/game-logic.js
+++ b/game-logic.js
@@ -1,0 +1,80 @@
+(function initLogic(root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.JeopardishLogic = factory();
+  }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function logicFactory() {
+  'use strict';
+
+  function cleanAnswer(answer) {
+    return String(answer || '')
+      .toLowerCase()
+      .replace(/^(what|who|where|when)\s+(is|are|was|were)\s+/i, '')
+      .replace(/^(a|an|the)\s+/i, '')
+      .replace(/[^a-z0-9]/g, '')
+      .trim();
+  }
+
+  function getLevenshteinDistance(a, b) {
+    if (a.length === 0) return b.length;
+    if (b.length === 0) return a.length;
+
+    const matrix = Array.from({ length: b.length + 1 }, () => []);
+
+    for (let i = 0; i <= b.length; i += 1) matrix[i][0] = i;
+    for (let j = 0; j <= a.length; j += 1) matrix[0][j] = j;
+
+    for (let i = 1; i <= b.length; i += 1) {
+      for (let j = 1; j <= a.length; j += 1) {
+        const cost = b[i - 1] === a[j - 1] ? 0 : 1;
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + cost,
+        );
+      }
+    }
+
+    return matrix[b.length][a.length];
+  }
+
+  function compareAnswers(userAnswerRaw, correctAnswerRaw) {
+    const userAnswer = cleanAnswer(userAnswerRaw);
+    const correctAnswer = cleanAnswer(correctAnswerRaw);
+
+    if (!userAnswer || !correctAnswer) {
+      return false;
+    }
+
+    if (userAnswer === correctAnswer) {
+      return true;
+    }
+
+    const levenshteinDistance = getLevenshteinDistance(userAnswer, correctAnswer);
+    return levenshteinDistance <= Math.min(3, Math.floor(correctAnswer.length / 2));
+  }
+
+  function parseClueValue(value, fallback = 100) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return Math.round(value);
+    }
+
+    if (typeof value === 'string') {
+      const digits = value.replace(/[^0-9]/g, '');
+      const parsed = Number(digits);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+
+    return fallback;
+  }
+
+  return {
+    cleanAnswer,
+    getLevenshteinDistance,
+    compareAnswers,
+    parseClueValue,
+  };
+}));

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css">
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    <script defer src="game-logic.js"></script>
     <script defer src="app.js"></script>
 </head>
 
@@ -51,6 +52,7 @@
 
             <!-- SPEECH BUBBLE -->
             <div class="speech-bubble">
+                <p id="statusMessage" class="status-message" aria-live="polite"></p>
                 <div id="categoryBox"></div>
                 <div id="questionBox"></div>
                 <div id="answerBox"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,11 @@
 {
   "dependencies": {
     "openai": "^4.53.2"
+  },
+  "scripts": {
+    "validate:questions": "node scripts/validate-questions.mjs",
+    "check:js": "node --check game-logic.js && node --check app.js",
+    "triage:branches": "bash scripts/branch-triage-report.sh",
+    "test": "node --test tests/*.test.mjs"
   }
 }

--- a/reports/branch-triage-2026-04-03.md
+++ b/reports/branch-triage-2026-04-03.md
@@ -1,0 +1,43 @@
+# Branch Triage Report (2026-04-03 UTC)
+
+- Base branch target: `work`
+- Remotes configured: 0
+
+## Local branches
+
+- `work` | 2026-04-03 | Codex | docs: add branch cleanup plan and .gitignore baseline
+
+## Remote branches
+
+_No remotes configured in this clone._
+
+## Historic branch names inferred from merge commits
+
+ -      12 updates
+ -      10 master
+ -       5 github-pages
+ -       5 gh-pages
+ -       2 test
+ -       2 alex-1
+ -       1 newupdates
+ -       1 newnewnewnewnewnew
+ -       1 mobile-first-overhaul
+ -       1 dependabot/npm_and_yarn/multi-d54dc5d3e6
+
+## Branches merged into work
+
+ - * work
+
+## Branches NOT merged into work
+
+
+## Recommended action template
+
+Fill this section during review:
+
+- merge-now:
+  - 
+- cherry-pick-later:
+  - 
+- archive-delete:
+  - 

--- a/reports/branch-triage-2026-04-05.md
+++ b/reports/branch-triage-2026-04-05.md
@@ -1,0 +1,43 @@
+# Branch Triage Report (2026-04-05 UTC)
+
+- Base branch target: `work`
+- Remotes configured: 0
+
+## Local branches
+
+- `work` | 2026-04-05 | Codex | docs: add 2026-04-05 branch decision matrix and triage report
+
+## Remote branches
+
+_No remotes configured in this clone._
+
+## Historic branch names inferred from merge commits
+
+ -      12 updates
+ -      10 master
+ -       5 github-pages
+ -       5 gh-pages
+ -       2 test
+ -       2 alex-1
+ -       1 newupdates
+ -       1 newnewnewnewnewnew
+ -       1 mobile-first-overhaul
+ -       1 dependabot/npm_and_yarn/multi-d54dc5d3e6
+
+## Branches merged into work
+
+ - * work
+
+## Branches NOT merged into work
+
+
+## Recommended action template
+
+Fill this section during review:
+
+- merge-now:
+  - 
+- cherry-pick-later:
+  - 
+- archive-delete:
+  - 

--- a/scripts/branch-triage-report.sh
+++ b/scripts/branch-triage-report.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="${1:-main}"
+OUT_DIR="${2:-reports}"
+DATE_UTC="$(date -u +%Y-%m-%d)"
+OUT_FILE="${OUT_DIR}/branch-triage-${DATE_UTC}.md"
+
+mkdir -p "$OUT_DIR"
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Not a git repository." >&2
+  exit 1
+fi
+
+REMOTE_COUNT="$(git remote | wc -l | tr -d ' ')"
+HAS_BASE=0
+if git show-ref --verify --quiet "refs/heads/${BASE_BRANCH}" || git show-ref --verify --quiet "refs/remotes/origin/${BASE_BRANCH}"; then
+  HAS_BASE=1
+fi
+
+{
+  echo "# Branch Triage Report (${DATE_UTC} UTC)"
+  echo
+  echo "- Base branch target: \`${BASE_BRANCH}\`"
+  echo "- Remotes configured: ${REMOTE_COUNT}"
+  echo
+
+  echo "## Local branches"
+  echo
+  git for-each-ref --sort=-committerdate refs/heads --format='- `%(refname:short)` | %(committerdate:short) | %(authorname) | %(subject)'
+  echo
+
+  echo "## Remote branches"
+  echo
+  if [ "$REMOTE_COUNT" -eq 0 ]; then
+    echo "_No remotes configured in this clone._"
+  else
+    git for-each-ref --sort=-committerdate refs/remotes --format='- `%(refname:short)` | %(committerdate:short) | %(authorname) | %(subject)'
+  fi
+  echo
+
+  echo "## Historic branch names inferred from merge commits"
+  echo
+  git log --merges --pretty=%s | \
+    sed -nE "s/.*from [^/]+\/(.+)$/\1/p; s/.*Merge branch '([^']+)'.*/\1/p" | \
+    sort | uniq -c | sort -nr | sed 's/^/ - /'
+  echo
+
+  if [ "$HAS_BASE" -eq 1 ]; then
+    if git show-ref --verify --quiet "refs/heads/${BASE_BRANCH}"; then
+      RESOLVED_BASE="$BASE_BRANCH"
+    else
+      RESOLVED_BASE="origin/${BASE_BRANCH}"
+    fi
+
+    echo "## Branches merged into ${RESOLVED_BASE}"
+    echo
+    git branch -a --merged "$RESOLVED_BASE" | sed 's/^/ - /'
+    echo
+
+    echo "## Branches NOT merged into ${RESOLVED_BASE}"
+    echo
+    git branch -a --no-merged "$RESOLVED_BASE" | sed 's/^/ - /'
+    echo
+  else
+    echo "## Merge status checks"
+    echo
+    echo "Could not resolve base branch \`${BASE_BRANCH}\`."
+    echo "Run again with an existing base, e.g.:"
+    echo
+    echo "\`scripts/branch-triage-report.sh master\`"
+    echo
+  fi
+
+  echo "## Recommended action template"
+  echo
+  cat <<'TEMPLATE'
+Fill this section during review:
+
+- merge-now:
+  - 
+- cherry-pick-later:
+  - 
+- archive-delete:
+  - 
+TEMPLATE
+} > "$OUT_FILE"
+
+echo "Wrote $OUT_FILE"

--- a/scripts/validate-questions.mjs
+++ b/scripts/validate-questions.mjs
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+
+const path = 'questions/jeopardy-questions.json';
+const raw = fs.readFileSync(path, 'utf-8');
+const data = JSON.parse(raw);
+
+if (!Array.isArray(data) || data.length === 0) {
+  throw new Error('questions/jeopardy-questions.json must be a non-empty array');
+}
+
+let bad = 0;
+for (const [index, item] of data.entries()) {
+  const hasCategory = typeof item.category === 'string' && item.category.trim().length > 0;
+  const hasQuestion = typeof item.question === 'string' && item.question.trim().length > 0;
+  const hasAnswer = typeof item.answer === 'string' && item.answer.trim().length > 0;
+
+  if (!hasCategory || !hasQuestion || !hasAnswer) {
+    bad += 1;
+    console.error(`Invalid question at index ${index}`);
+  }
+}
+
+if (bad > 0) {
+  throw new Error(`Validation failed: ${bad} malformed question objects.`);
+}
+
+console.log(`Validated ${data.length} questions successfully.`);

--- a/style.css
+++ b/style.css
@@ -89,6 +89,20 @@ html, body {
     text-transform: uppercase;
 }
 
+.status-message {
+    min-height: 1.2rem;
+    margin-bottom: 0.5rem;
+    color: #ffe189;
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+button:focus-visible,
+input:focus-visible {
+    outline: 3px solid #ffdd00;
+    outline-offset: 2px;
+}
+
 /* User Input Section */
 .input-div {
     display: flex;
@@ -117,6 +131,11 @@ html, body {
     border: none;
     border-radius: 10px;
     cursor: pointer;
+}
+
+button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
 }
 
 /* Speech Bubble */

--- a/tests/game-logic.test.mjs
+++ b/tests/game-logic.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const logic = require('../game-logic.js');
+
+test('cleanAnswer strips common prefixes and punctuation', () => {
+  assert.equal(logic.cleanAnswer('What is The Eiffel Tower?'), 'eiffeltower');
+  assert.equal(logic.cleanAnswer('Who was an Apple?'), 'apple');
+});
+
+test('compareAnswers supports exact normalized match', () => {
+  assert.equal(logic.compareAnswers('What is Abraham Lincoln?', 'Abraham Lincoln'), true);
+});
+
+test('compareAnswers supports fuzzy match with small typo', () => {
+  assert.equal(logic.compareAnswers('washngton', 'Washington'), true);
+});
+
+test('compareAnswers does not accept tiny substring guesses', () => {
+  assert.equal(logic.compareAnswers('cop', 'Copernicus'), false);
+  assert.equal(logic.compareAnswers('a', 'Australia'), false);
+});
+
+test('compareAnswers rejects empty values', () => {
+  assert.equal(logic.compareAnswers('', 'anything'), false);
+  assert.equal(logic.compareAnswers('something', ''), false);
+});
+
+test('parseClueValue handles numeric, currency strings, and fallback', () => {
+  assert.equal(logic.parseClueValue(400), 400);
+  assert.equal(logic.parseClueValue('$1,200'), 1200);
+  assert.equal(logic.parseClueValue('unknown', 100), 100);
+});


### PR DESCRIPTION
### Motivation

- Provide a basic CI pipeline and repo hygiene to catch syntax errors, validate data, and run unit tests on PRs via `/.github/workflows/ci.yml`.
- Improve repository maintainability by adding a `.gitignore`, branch-triage scripts, and branch/decision docs to support cleanup and production hardening.
- Separate core answer-matching logic from the UI so it can be tested and maintained independently by introducing `game-logic.js`.
- Modernize and harden the frontend app runtime (`app.js`/`index.html`/`style.css`) to use a clearer state model, DOM bindings, and better error handling.

### Description

- Added a CI workflow at `/.github/workflows/ci.yml` to run `node scripts/validate-questions.mjs`, `npm run check:js`, and `npm test` on pushes and PRs.
- Introduced repository hygiene and triage tooling including `.gitignore`, `scripts/branch-triage-report.sh`, `scripts/validate-questions.mjs`, plus planning docs `BRANCH_CLEANUP_PLAN.md`, `docs/BRANCH_DECISIONS_2026-04-05.md`, and supporting `reports/*` files.
- Extracted and exported game logic into `game-logic.js` with functions `cleanAnswer`, `compareAnswers`, `getLevenshteinDistance`, and `parseClueValue`, and refactored `app.js` to use that module, a structured `state`, improved UI updates, error fallbacks, and fetch timeout handling.
- Added test coverage and developer scripts by updating `package.json` scripts, adding `tests/game-logic.test.mjs`, and wiring the logic into `index.html` and minor UI/UX CSS updates in `style.css`.

### Testing

- Ran the question validator via `node scripts/validate-questions.mjs` which completed and confirmed the `questions/jeopardy-questions.json` dataset is non-empty and well-formed.
- Performed JS syntax checks via `npm run check:js` (runs `node --check game-logic.js` and `node --check app.js`) which succeeded without syntax errors.
- Executed unit tests with `npm test` (runs `node --test tests/*.test.mjs`) and all tests in `tests/game-logic.test.mjs` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cf7ed2c7a48329800b054c20737f6f)