### PR TITLE
Add open-PR MVP review script and April 25 triage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "validate:questions": "node scripts/validate-questions.mjs",
     "check:js": "node --check game-logic.js && node --check app.js",
     "triage:branches": "bash scripts/branch-triage-report.sh",
-    "test": "node --test tests/*.test.mjs"
+    "test": "node --test tests/*.test.mjs",
+    "review:open-prs": "bash scripts/review-open-prs-mvp.sh"
   }
 }

--- a/reports/branch-triage-2026-04-25.md
+++ b/reports/branch-triage-2026-04-25.md
@@ -1,0 +1,44 @@
+# Branch Triage Report (2026-04-25 UTC)
+
+- Base branch target: `work`
+- Remotes configured: 0
+
+## Local branches
+
+- `work` | 2026-04-25 | Alex Beckerman | Merge pull request #49 from AlexBaldman/codex/review-and-clean-up-branches-gwfwry
+
+## Remote branches
+
+_No remotes configured in this clone._
+
+## Historic branch names inferred from merge commits
+
+ -      12 updates
+ -      10 master
+ -       5 github-pages
+ -       5 gh-pages
+ -       2 test
+ -       2 alex-1
+ -       1 newupdates
+ -       1 newnewnewnewnewnew
+ -       1 mobile-first-overhaul
+ -       1 dependabot/npm_and_yarn/multi-d54dc5d3e6
+ -       1 codex/review-and-clean-up-branches-gwfwry
+
+## Branches merged into work
+
+ - * work
+
+## Branches NOT merged into work
+
+
+## Recommended action template
+
+Fill this section during review:
+
+- merge-now:
+  - 
+- cherry-pick-later:
+  - 
+- archive-delete:
+  - 

--- a/reports/pr-mvp-review-2026-04-25.md
+++ b/reports/pr-mvp-review-2026-04-25.md
@@ -1,0 +1,49 @@
+# Open PR + MVP Review (2026-04-25 UTC)
+
+- Base branch target: `work`
+- Remotes configured: 0
+- GitHub CLI available: no
+
+## Open pull requests
+
+No open PR metadata could be loaded from this checkout.
+
+Possible reasons:
+- No remote configured in this clone.
+- GitHub CLI is unavailable or unauthenticated.
+- Repo has no open pull requests.
+
+## MVP-oriented merge recommendations
+
+1. **Merge now (if still open and not yet in work)**
+   - `mobile-first-overhaul` (UX modernization baseline).
+   - `dependabot/npm_and_yarn/multi-d54dc5d3e6` (dependency/security improvements).
+2. **Cherry-pick selectively**
+   - `github-pages` / `gh-pages` deployment commits only (pick one deploy strategy).
+   - `alex-1` after commit-level review.
+3. **Close/delete once verified no unique commits**
+   - `test`, `newupdates`, `newnewnewnewnewnew`, and duplicate deploy branch naming.
+
+## Lost-change recovery checklist
+
+Run this once `origin` is attached:
+
+```bash
+git fetch --all --prune
+for b in mobile-first-overhaul dependabot/npm_and_yarn/multi-d54dc5d3e6 github-pages gh-pages alex-1 test newupdates newnewnewnewnewnew; do
+  echo "=== $b ==="
+  git log --oneline origin/work..origin/$b | head -n 25 || true
+  git diff --stat origin/work...origin/$b | head -n 25 || true
+done
+```
+
+## Deploy-updated-version plan
+
+1. Merge/cherry-pick approved PRs into `work`.
+2. Run quality gates:
+   - `npm run check:js`
+   - `npm run validate:questions`
+   - `npm test`
+3. Build a release commit/tag:
+   - `git tag -a v1.0.0-mvp -m "Publishable MVP"`
+4. Deploy to your chosen target (GitHub Pages or host of record) and smoke-test desktop/mobile.

--- a/scripts/review-open-prs-mvp.sh
+++ b/scripts/review-open-prs-mvp.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="${1:-work}"
+OUT_DIR="${2:-reports}"
+DATE_UTC="$(date -u +%Y-%m-%d)"
+OUT_FILE="${OUT_DIR}/pr-mvp-review-${DATE_UTC}.md"
+
+mkdir -p "$OUT_DIR"
+
+remote_count="$(git remote | wc -l | tr -d ' ')"
+
+have_gh=0
+if command -v gh >/dev/null 2>&1; then
+  have_gh=1
+fi
+
+open_pr_rows=""
+open_pr_count=0
+
+if [ "$have_gh" -eq 1 ] && [ "$remote_count" -gt 0 ]; then
+  if gh repo view >/dev/null 2>&1; then
+    # number\ttitle\thead\tbase\tisDraft\tupdatedAt\turl
+    open_pr_rows="$(gh pr list --state open --limit 200 --json number,title,headRefName,baseRefName,isDraft,updatedAt,url --template '{{range .}}{{.number}}\t{{.title}}\t{{.headRefName}}\t{{.baseRefName}}\t{{.isDraft}}\t{{.updatedAt}}\t{{.url}}\n{{end}}')"
+    if [ -n "$open_pr_rows" ]; then
+      open_pr_count="$(printf '%s' "$open_pr_rows" | awk 'NF>0' | wc -l | tr -d ' ')"
+    fi
+  fi
+fi
+
+{
+  echo "# Open PR + MVP Review (${DATE_UTC} UTC)"
+  echo
+  echo "- Base branch target: \`${BASE_BRANCH}\`"
+  echo "- Remotes configured: ${remote_count}"
+  echo "- GitHub CLI available: $([ "$have_gh" -eq 1 ] && echo yes || echo no)"
+  echo
+
+  echo "## Open pull requests"
+  echo
+
+  if [ "$open_pr_count" -eq 0 ]; then
+    echo "No open PR metadata could be loaded from this checkout."
+    echo
+    echo "Possible reasons:" 
+    echo "- No remote configured in this clone."
+    echo "- GitHub CLI is unavailable or unauthenticated."
+    echo "- Repo has no open pull requests."
+  else
+    echo "| PR | Title | Head | Base | Draft | Updated (UTC) |"
+    echo "|---:|---|---|---|---|---|"
+    while IFS=$'\t' read -r number title head base draft updated url; do
+      [ -z "${number}" ] && continue
+      echo "| [#${number}](${url}) | ${title} | \`${head}\` | \`${base}\` | ${draft} | ${updated} |"
+    done <<< "$open_pr_rows"
+  fi
+
+  echo
+  echo "## MVP-oriented merge recommendations"
+  echo
+  echo "1. **Merge now (if still open and not yet in ${BASE_BRANCH})**"
+  echo "   - \`mobile-first-overhaul\` (UX modernization baseline)."
+  echo "   - \`dependabot/npm_and_yarn/multi-d54dc5d3e6\` (dependency/security improvements)."
+  echo "2. **Cherry-pick selectively**"
+  echo "   - \`github-pages\` / \`gh-pages\` deployment commits only (pick one deploy strategy)."
+  echo "   - \`alex-1\` after commit-level review."
+  echo "3. **Close/delete once verified no unique commits**"
+  echo "   - \`test\`, \`newupdates\`, \`newnewnewnewnewnew\`, and duplicate deploy branch naming."
+
+  echo
+  echo "## Lost-change recovery checklist"
+  echo
+  cat <<'RECOVER'
+Run this once `origin` is attached:
+
+```bash
+git fetch --all --prune
+for b in mobile-first-overhaul dependabot/npm_and_yarn/multi-d54dc5d3e6 github-pages gh-pages alex-1 test newupdates newnewnewnewnewnew; do
+  echo "=== $b ==="
+  git log --oneline origin/work..origin/$b | head -n 25 || true
+  git diff --stat origin/work...origin/$b | head -n 25 || true
+done
+```
+RECOVER
+
+  echo
+  echo "## Deploy-updated-version plan"
+  echo
+  cat <<'DEPLOY'
+1. Merge/cherry-pick approved PRs into `work`.
+2. Run quality gates:
+   - `npm run check:js`
+   - `npm run validate:questions`
+   - `npm test`
+3. Build a release commit/tag:
+   - `git tag -a v1.0.0-mvp -m "Publishable MVP"`
+4. Deploy to your chosen target (GitHub Pages or host of record) and smoke-test desktop/mobile.
+DEPLOY
+} > "$OUT_FILE"
+
+echo "Wrote $OUT_FILE"


### PR DESCRIPTION
### Motivation

- Provide a repeatable, local workflow to review open pull requests and produce MVP-focused merge/cherry-pick/delete recommendations.
- Make the review resilient when a remote or the GitHub CLI is unavailable and capture a recovery checklist for lost changes.
- Include a concrete deploy plan and quality-gate steps so the repo can be hardened and released to a publishable MVP.

### Description

- Add `scripts/review-open-prs-mvp.sh`, a standalone script that lists open PRs via the GitHub CLI when available, falls back gracefully, and emits an MVP-oriented review report and lost-change checklist.
- Add an npm shortcut `review:open-prs` in `package.json` to run the script conveniently as `npm run review:open-prs -- work`.
- Add generated reports `reports/pr-mvp-review-2026-04-25.md` and `reports/branch-triage-2026-04-25.md` containing current recommendations, historic branch names, and a deploy/recovery plan.
- Make the script executable and commit the new files so the workflow is repeatable in this repository clone.

### Testing

- Ran `npm run triage:branches -- work`, which produced `reports/branch-triage-2026-04-25.md` successfully.
- Ran `npm run review:open-prs -- work`, which produced `reports/pr-mvp-review-2026-04-25.md` successfully (script handles missing remotes/CLI gracefully).
- Ran `npm run check:js` and `npm run validate:questions`, with `validate:questions` reporting validation of 216,930 questions without error.
- Ran `npm test`, and the test suite passed (6 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2389dd7c8329b73c10aea7b28e22)