### PR TITLE
Add Character Genome v1 and embodiment adapter boundary

### DIFF
--- a/docs/CHARACTER_FACTORY_ARCHITECTURE.md
+++ b/docs/CHARACTER_FACTORY_ARCHITECTURE.md
@@ -1,0 +1,83 @@
+# Character Factory Architecture v0.1
+
+## Purpose
+
+Character Factory defines a canonical identity contract that can survive changes in renderer, art style, body topology, wardrobe, animation backend, and delivery surface. A character is data first; meshes, sprites, portraits, and compact companions are embodiments of that identity.
+
+## Core rule
+
+`CharacterGenome` must not depend on Three.js, PixiJS, Blender, MetaHuman, Codex Pets, or any other specific implementation. Those systems belong behind adapters.
+
+## Genome
+
+The v0.1 genome contains:
+
+- stable identity and tags
+- morphology (`humanoid`, `quadruped`, or `custom`)
+- body proportions with optional source confidence
+- face parameters with photo/video/depth provenance
+- appearance profiles
+- wardrobe slots and overlays
+- rig family, attachment targets, and IK-chain metadata
+- animation vocabulary and personality modifiers
+- one or more embodiments
+- provenance and rights metadata
+
+## Confidence-aware capture
+
+Photo- or scan-derived values are stored as `{ value, confidence, source }` instead of baking the estimate directly into a mesh. Better capture pipelines can later regenerate representations while preserving identity.
+
+## Embodiments
+
+Supported v0.1 embodiment families:
+
+- `game-3d`
+- `sprite-2d`
+- `pixel`
+- `portrait`
+- `desktop-companion`
+
+An embodiment selects a renderer-facing representation, optional rig override, animation set, interaction profile, scale, and adapter. The canonical genome remains unchanged.
+
+## Wardrobe
+
+Wardrobe is semantic and slot-based. The character owns a loadout of garment/item asset IDs; renderers and garment systems decide how those IDs become meshes, sprites, layers, or materials. Wardrobe swaps therefore preserve identity, rig metadata, and embodiments.
+
+## Rig and attachment contract
+
+The core stores semantic attachment targets (`left-hand`, `right-hand`, `mouth`, `back`, etc.) plus optional custom targets. Adapter layers map those targets to renderer/rig-specific bones. This allows an instrument or prop factory to describe how an item is held without owning a character-specific animation.
+
+## Animation profile
+
+Animation data is intentionally semantic:
+
+- locomotion set
+- performance sets
+- facial profile
+- stride
+- posture
+- energy
+- looseness
+- expressiveness
+
+Animation engines can translate the same profile into skeletal clips, procedural motion, sprite states, or compact companion behaviors.
+
+## Adapter boundary
+
+`CharacterFactory.embody()` selects an adapter for an embodiment. The included descriptor adapter proves the contract without binding the engine to any renderer. Future adapters can target Three.js, PixiJS, Blender export, MetaHuman-style pipelines, or Codex/custom-pet packaging.
+
+Pet compatibility is intentionally downstream. Lessons that generalize should move into the genome; platform-specific packaging must remain in the adapter.
+
+## Stress-test fixtures
+
+The test suite validates one schema against:
+
+1. photo-derived realistic human with confidence metadata
+2. marching-band trombonist with instrument/wardrobe requirements
+3. Archie as a quadruped with canine rig and pixel/desktop embodiments
+4. Schmalex LeTrec as a stylized host with pixel and 3D embodiments
+5. a compact desktop-only companion
+
+## Next implementation step
+
+Build the first real renderer adapter around the existing host avatar system rather than creating a parallel character renderer. Map a `CharacterGenome` embodiment into the current `HostAvatarPack`/host performance pipeline, then use that integration to identify the smallest general-purpose wardrobe and animation interfaces needed for StadiumSlice performers.

--- a/src/character/character-factory.js
+++ b/src/character/character-factory.js
@@ -1,0 +1,63 @@
+(function initCharacterFactory(root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory(require('./character-genome.js'));
+  else root.UinverseCharacterFactory = factory(root.UinverseCharacterGenome);
+}(typeof globalThis !== 'undefined' ? globalThis : this, function characterFactoryModule(genomeApi) {
+  'use strict';
+
+  const { normalizeCharacterGenome, selectEmbodiment } = genomeApi;
+
+  class CharacterFactory {
+    constructor({ adapters = [] } = {}) {
+      this.adapters = new Map();
+      adapters.forEach((adapter) => this.registerAdapter(adapter));
+    }
+
+    registerAdapter(adapter) {
+      if (!adapter || typeof adapter.id !== 'string' || typeof adapter.canHandle !== 'function' || typeof adapter.build !== 'function') {
+        throw new TypeError('Character adapter requires id, canHandle(), and build()');
+      }
+      this.adapters.set(adapter.id, adapter);
+      return this;
+    }
+
+    create(input) {
+      return normalizeCharacterGenome(input);
+    }
+
+    async embody(genomeInput, idOrKind, context = {}) {
+      const genome = genomeInput?.schema ? genomeInput : normalizeCharacterGenome(genomeInput);
+      const embodiment = selectEmbodiment(genome, idOrKind);
+      if (!embodiment) throw new Error(`Unknown embodiment: ${idOrKind}`);
+      const candidates = embodiment.adapter
+        ? [this.adapters.get(embodiment.adapter)].filter(Boolean)
+        : [...this.adapters.values()].filter((adapter) => adapter.canHandle({ genome, embodiment, context }));
+      const adapter = candidates[0];
+      if (!adapter) return { genome, embodiment, status: 'unresolved', reason: 'no-adapter' };
+      return adapter.build({ genome, embodiment, context });
+    }
+  }
+
+  function createDescriptorAdapter({ id, kinds = [] }) {
+    return {
+      id,
+      canHandle({ embodiment }) { return kinds.includes(embodiment.kind); },
+      async build({ genome, embodiment }) {
+        return Object.freeze({
+          status: 'ready',
+          adapter: id,
+          characterId: genome.id,
+          embodimentId: embodiment.id,
+          kind: embodiment.kind,
+          renderer: embodiment.renderer,
+          representationAssetId: embodiment.representationAssetId,
+          rigProfile: embodiment.rigProfile || genome.rig.family,
+          animationSet: embodiment.animationSet.length ? embodiment.animationSet : [genome.animation.locomotionSet, ...genome.animation.performanceSets],
+          wardrobe: genome.wardrobe,
+          attachments: genome.rig.attachments,
+        });
+      },
+    };
+  }
+
+  return { CharacterFactory, createDescriptorAdapter };
+}));

--- a/src/character/character-genome.js
+++ b/src/character/character-genome.js
@@ -1,0 +1,236 @@
+(function initCharacterGenome(root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.UinverseCharacterGenome = factory();
+}(typeof globalThis !== 'undefined' ? globalThis : this, function characterGenomeFactory() {
+  'use strict';
+
+  const CHARACTER_SCHEMA = 'uinverse.character-genome';
+  const CHARACTER_VERSION = 1;
+  const EMBODIMENT_KINDS = Object.freeze(['game-3d','sprite-2d','pixel','portrait','desktop-companion']);
+  const BODY_KINDS = Object.freeze(['humanoid','quadruped','custom']);
+  const WARDROBE_SLOTS = Object.freeze(['head','hair','face','eyes','ears','neck','undershirt','shirt','outerwear','hands','waist','legs','feet','back','left-hand','right-hand']);
+  const ATTACHMENT_TARGETS = Object.freeze(['head','mouth','chest','back','left-hand','right-hand','left-foot','right-foot','tail-base']);
+
+  class CharacterGenomeError extends Error {
+    constructor(issues) {
+      super(`Invalid CharacterGenome: ${issues.join('; ')}`);
+      this.name = 'CharacterGenomeError';
+      this.issues = Object.freeze([...issues]);
+    }
+  }
+
+  function deepFreeze(value) {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+    Object.values(value).forEach(deepFreeze);
+    return Object.freeze(value);
+  }
+
+  function cleanText(value, maxLength = 180) {
+    return String(value || '').replace(/\s+/g, ' ').trim().slice(0, maxLength);
+  }
+
+  function clamp01(value, fallback = 0.5) {
+    const n = Number(value);
+    return Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : fallback;
+  }
+
+  function confidenceValue(input, fallback = 0.5) {
+    if (input && typeof input === 'object' && 'value' in input) {
+      return { value: Number(input.value) || 0, confidence: clamp01(input.confidence, 1), source: cleanText(input.source, 80) || 'authored' };
+    }
+    return { value: Number(input ?? fallback) || 0, confidence: 1, source: 'authored' };
+  }
+
+  function normalizeMorphology(input = {}) {
+    const kind = BODY_KINDS.includes(input.kind) ? input.kind : 'humanoid';
+    const proportions = {};
+    Object.entries(input.proportions || {}).forEach(([key, value]) => {
+      if (/^[a-z][a-zA-Z0-9]*$/.test(key)) proportions[key] = confidenceValue(value);
+    });
+    return {
+      kind,
+      species: cleanText(input.species, 100) || (kind === 'humanoid' ? 'human' : 'unspecified'),
+      heightMeters: confidenceValue(input.heightMeters, kind === 'quadruped' ? 0.35 : 1.75),
+      proportions,
+    };
+  }
+
+  function normalizeFace(input = {}) {
+    const parameters = {};
+    Object.entries(input.parameters || {}).forEach(([key, value]) => {
+      if (/^[a-z][a-zA-Z0-9]*$/.test(key)) parameters[key] = confidenceValue(value);
+    });
+    return {
+      topology: cleanText(input.topology, 80) || 'generic',
+      parameters,
+      sourceCapture: {
+        mode: ['none','single-photo','multi-photo','video','depth-scan'].includes(input.sourceCapture?.mode) ? input.sourceCapture.mode : 'none',
+        assetIds: Array.isArray(input.sourceCapture?.assetIds) ? input.sourceCapture.assetIds.map((id) => cleanText(id, 120)).filter(Boolean) : [],
+      },
+    };
+  }
+
+  function normalizeWardrobe(input = {}, issues) {
+    const slots = {};
+    Object.entries(input.slots || {}).forEach(([slot, item]) => {
+      if (!WARDROBE_SLOTS.includes(slot)) {
+        issues.push(`wardrobe.slots.${slot} is not supported`);
+        return;
+      }
+      if (!item) return;
+      slots[slot] = {
+        assetId: cleanText(item.assetId || item, 140),
+        variant: cleanText(item.variant, 100),
+        materialPreset: cleanText(item.materialPreset, 100),
+      };
+    });
+    return {
+      slots,
+      overlays: Array.isArray(input.overlays) ? input.overlays.map((item) => ({
+        assetId: cleanText(item.assetId, 140),
+        kind: cleanText(item.kind, 80),
+        region: cleanText(item.region, 80),
+      })).filter((item) => item.assetId) : [],
+    };
+  }
+
+  function normalizeRig(input = {}, morphologyKind, issues) {
+    const attachments = {};
+    Object.entries(input.attachments || {}).forEach(([key, value]) => {
+      if (!ATTACHMENT_TARGETS.includes(key) && !key.startsWith('custom:')) {
+        issues.push(`rig.attachments.${key} is not a supported target`);
+        return;
+      }
+      attachments[key] = {
+        bone: cleanText(value?.bone, 120),
+        position: Array.isArray(value?.position) ? value.position.slice(0, 3).map((n) => Number(n) || 0) : [0,0,0],
+        rotation: Array.isArray(value?.rotation) ? value.rotation.slice(0, 3).map((n) => Number(n) || 0) : [0,0,0],
+      };
+    });
+    return {
+      family: cleanText(input.family, 100) || (morphologyKind === 'humanoid' ? 'humanoid-v1' : `${morphologyKind}-v1`),
+      retargetProfile: cleanText(input.retargetProfile, 100),
+      attachments,
+      ikChains: Array.isArray(input.ikChains) ? input.ikChains.map((chain) => ({
+        id: cleanText(chain.id, 80),
+        root: cleanText(chain.root, 100),
+        tip: cleanText(chain.tip, 100),
+        target: cleanText(chain.target, 100),
+      })).filter((chain) => chain.id && chain.root && chain.tip) : [],
+    };
+  }
+
+  function normalizeAnimation(input = {}) {
+    return {
+      locomotionSet: cleanText(input.locomotionSet, 120) || 'default',
+      performanceSets: Array.isArray(input.performanceSets) ? [...new Set(input.performanceSets.map((v) => cleanText(v, 120)).filter(Boolean))] : [],
+      facialProfile: cleanText(input.facialProfile, 100),
+      modifiers: {
+        stride: clamp01(input.modifiers?.stride, 0.5),
+        posture: clamp01(input.modifiers?.posture, 0.5),
+        energy: clamp01(input.modifiers?.energy, 0.5),
+        looseness: clamp01(input.modifiers?.looseness, 0.5),
+        expressiveness: clamp01(input.modifiers?.expressiveness, 0.5),
+      },
+    };
+  }
+
+  function normalizeEmbodiment(item, index, issues) {
+    const id = cleanText(item?.id, 100);
+    if (!id || !/^[a-z0-9-]+$/.test(id)) issues.push(`embodiments[${index}].id must be kebab-case`);
+    const kind = EMBODIMENT_KINDS.includes(item?.kind) ? item.kind : '';
+    if (!kind) issues.push(`embodiments[${index}].kind is unsupported`);
+    return {
+      id,
+      kind,
+      renderer: cleanText(item?.renderer, 80) || (kind === 'game-3d' ? 'three' : 'sprite'),
+      representationAssetId: cleanText(item?.representationAssetId, 140),
+      rigProfile: cleanText(item?.rigProfile, 120),
+      animationSet: Array.isArray(item?.animationSet) ? [...new Set(item.animationSet.map((v) => cleanText(v, 100)).filter(Boolean))] : [],
+      interactionProfile: cleanText(item?.interactionProfile, 100),
+      scale: Number.isFinite(Number(item?.scale)) ? Number(item.scale) : 1,
+      adapter: cleanText(item?.adapter, 100),
+    };
+  }
+
+  function normalizeCharacterGenome(input = {}) {
+    const issues = [];
+    const id = cleanText(input.id, 100);
+    const displayName = cleanText(input.displayName, 140);
+    if (!id || !/^[a-z0-9-]+$/.test(id)) issues.push('id must be kebab-case');
+    if (!displayName) issues.push('displayName is required');
+
+    const morphology = normalizeMorphology(input.morphology);
+    const embodiments = Array.isArray(input.embodiments)
+      ? input.embodiments.map((item, index) => normalizeEmbodiment(item, index, issues))
+      : [];
+    if (!embodiments.length) issues.push('embodiments requires at least one embodiment');
+    if (new Set(embodiments.map((item) => item.id)).size !== embodiments.length) issues.push('embodiment ids must be unique');
+
+    const result = {
+      schema: CHARACTER_SCHEMA,
+      version: CHARACTER_VERSION,
+      id,
+      displayName,
+      identity: {
+        archetype: cleanText(input.identity?.archetype, 120),
+        tags: Array.isArray(input.identity?.tags) ? [...new Set(input.identity.tags.map((v) => cleanText(v, 80)).filter(Boolean))] : [],
+      },
+      morphology,
+      face: normalizeFace(input.face),
+      appearance: {
+        skinProfile: cleanText(input.appearance?.skinProfile, 120),
+        hairProfile: cleanText(input.appearance?.hairProfile, 120),
+        eyeProfile: cleanText(input.appearance?.eyeProfile, 120),
+        materialProfile: cleanText(input.appearance?.materialProfile, 120),
+      },
+      wardrobe: normalizeWardrobe(input.wardrobe, issues),
+      rig: normalizeRig(input.rig, morphology.kind, issues),
+      animation: normalizeAnimation(input.animation),
+      personality: Object.fromEntries(Object.entries(input.personality || {}).filter(([key]) => /^[a-z][a-zA-Z0-9]*$/.test(key)).map(([key, value]) => [key, clamp01(value, 0.5)])),
+      embodiments,
+      provenance: {
+        source: cleanText(input.provenance?.source, 100) || 'authored',
+        sourceAssetIds: Array.isArray(input.provenance?.sourceAssetIds) ? input.provenance.sourceAssetIds.map((v) => cleanText(v, 140)).filter(Boolean) : [],
+        generator: cleanText(input.provenance?.generator, 120),
+        generatorVersion: cleanText(input.provenance?.generatorVersion, 80),
+      },
+      rights: {
+        status: cleanText(input.rights?.status, 100) || 'review-required',
+        notes: cleanText(input.rights?.notes, 300),
+      },
+    };
+
+    if (issues.length) throw new CharacterGenomeError(issues);
+    return deepFreeze(result);
+  }
+
+  function selectEmbodiment(genome, idOrKind) {
+    return genome.embodiments.find((item) => item.id === idOrKind)
+      || genome.embodiments.find((item) => item.kind === idOrKind)
+      || null;
+  }
+
+  function withWardrobe(genome, patch = {}) {
+    const source = JSON.parse(JSON.stringify(genome));
+    delete source.schema;
+    delete source.version;
+    source.wardrobe = source.wardrobe || { slots: {}, overlays: [] };
+    source.wardrobe.slots = { ...source.wardrobe.slots, ...(patch.slots || {}) };
+    if (Array.isArray(patch.overlays)) source.wardrobe.overlays = patch.overlays;
+    return normalizeCharacterGenome(source);
+  }
+
+  return {
+    ATTACHMENT_TARGETS,
+    BODY_KINDS,
+    CHARACTER_SCHEMA,
+    CHARACTER_VERSION,
+    CharacterGenomeError,
+    EMBODIMENT_KINDS,
+    WARDROBE_SLOTS,
+    normalizeCharacterGenome,
+    selectEmbodiment,
+    withWardrobe,
+  };
+}));

--- a/tests/character-factory.test.mjs
+++ b/tests/character-factory.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const genomeApi = require('../src/character/character-genome.js');
+const { CharacterFactory, createDescriptorAdapter } = require('../src/character/character-factory.js');
+
+const humanBase = {
+  id: 'photo-human', displayName: 'Photo Human',
+  morphology: { kind: 'humanoid', species: 'human', heightMeters: { value: 1.78, confidence: 0.82, source: 'multi-photo' }, proportions: { shoulderWidth: { value: 0.58, confidence: 0.76, source: 'multi-photo' } } },
+  face: { topology: 'human-v1', sourceCapture: { mode: 'multi-photo', assetIds: ['capture-front','capture-side'] }, parameters: { jawWidth: { value: 0.61, confidence: 0.91, source: 'multi-photo' } } },
+  wardrobe: { slots: { shirt: { assetId: 'garment.basic-tee' } } },
+  rig: { family: 'humanoid-v1', attachments: { 'right-hand': { bone: 'hand.R' }, mouth: { bone: 'head' } }, ikChains: [{ id: 'right-arm', root: 'upper_arm.R', tip: 'hand.R', target: 'right-hand' }] },
+  animation: { locomotionSet: 'human-standard', performanceSets: ['talk'], modifiers: { stride: 0.55, posture: 0.6, energy: 0.5 } },
+  embodiments: [{ id: 'realistic-3d', kind: 'game-3d', renderer: 'three', representationAssetId: 'model.photo-human.glb' }, { id: 'portrait', kind: 'portrait', renderer: 'canvas', representationAssetId: 'portrait.photo-human' }],
+};
+
+const marchingMusician = { ...humanBase, id: 'marching-trombonist', displayName: 'Marching Trombonist', identity: { archetype: 'marching-musician' }, wardrobe: { slots: { shirt: { assetId: 'uniform.band-jacket' }, head: { assetId: 'uniform.shako' }, 'right-hand': { assetId: 'instrument.trombone' } } }, animation: { locomotionSet: 'march-standard', performanceSets: ['trombone-performance'], modifiers: { stride: 0.62, posture: 0.76, energy: 0.73 } } };
+
+const archie = { id: 'archie', displayName: 'Archie', morphology: { kind: 'quadruped', species: 'maltese-mix', heightMeters: 0.28, proportions: { tailPlume: 0.95, earFlop: 0.72 } }, face: { topology: 'canine-v1', parameters: { suspicion: 0.88 } }, rig: { family: 'quadruped-canine-v1', attachments: { 'tail-base': { bone: 'tail.01' }, mouth: { bone: 'jaw' } } }, animation: { locomotionSet: 'small-dog-chaos', performanceSets: ['suspicious-stare','manic-victory'], modifiers: { energy: 0.82, looseness: 0.78, expressiveness: 0.9 } }, embodiments: [{ id: 'platformer-pixel', kind: 'pixel', renderer: 'sprite', representationAssetId: 'sprite.archie.platformer' }, { id: 'desktop-archie', kind: 'desktop-companion', renderer: 'sprite', representationAssetId: 'sprite.archie.pet', interactionProfile: 'desktop-reactive' }] };
+
+const schmalex = { ...humanBase, id: 'schmalex-letrec', displayName: 'Schmalex LeTrec', identity: { archetype: 'beach-game-show-host', tags: ['surfer','host'] }, personality: { confidence: 0.96, weirdness: 0.81 }, embodiments: [{ id: 'broadcast-pixel', kind: 'pixel', renderer: 'sprite', representationAssetId: 'assets/hosts/xander/v1/looks/broadcast-grid-black.png' }, { id: 'stage-3d', kind: 'game-3d', renderer: 'three', representationAssetId: 'model.schmalex' }] };
+
+const desktopOnly = { ...humanBase, id: 'tiny-companion', displayName: 'Tiny Companion', embodiments: [{ id: 'desktop', kind: 'desktop-companion', renderer: 'sprite', representationAssetId: 'sprite.tiny', adapter: 'descriptor-pet' }] };
+
+const fixtures = [humanBase, marchingMusician, archie, schmalex, desktopOnly];
+
+test('five distinct fixtures normalize under one renderer-agnostic genome', () => {
+  for (const fixture of fixtures) {
+    const genome = genomeApi.normalizeCharacterGenome(fixture);
+    assert.equal(genome.schema, genomeApi.CHARACTER_SCHEMA);
+    assert.equal(Object.isFrozen(genome), true);
+    assert.ok(genome.embodiments.length >= 1);
+  }
+});
+
+test('photo-derived values preserve confidence and capture provenance', () => {
+  const genome = genomeApi.normalizeCharacterGenome(humanBase);
+  assert.equal(genome.face.sourceCapture.mode, 'multi-photo');
+  assert.equal(genome.face.parameters.jawWidth.confidence, 0.91);
+  assert.equal(genome.morphology.heightMeters.source, 'multi-photo');
+});
+
+test('one identity supports multiple embodiments without renderer coupling', () => {
+  const genome = genomeApi.normalizeCharacterGenome(schmalex);
+  assert.equal(genomeApi.selectEmbodiment(genome, 'pixel').renderer, 'sprite');
+  assert.equal(genomeApi.selectEmbodiment(genome, 'game-3d').renderer, 'three');
+  assert.equal(genome.id, 'schmalex-letrec');
+});
+
+test('wardrobe swaps preserve identity, rig, and embodiments', () => {
+  const original = genomeApi.normalizeCharacterGenome(marchingMusician);
+  const changed = genomeApi.withWardrobe(original, { slots: { head: { assetId: 'uniform.cowboy-hat' } } });
+  assert.equal(changed.id, original.id);
+  assert.equal(changed.rig.family, original.rig.family);
+  assert.deepEqual(changed.embodiments, original.embodiments);
+  assert.equal(changed.wardrobe.slots.head.assetId, 'uniform.cowboy-hat');
+});
+
+test('non-human Archie uses the same identity contract with a different rig family', () => {
+  const genome = genomeApi.normalizeCharacterGenome(archie);
+  assert.equal(genome.morphology.kind, 'quadruped');
+  assert.equal(genome.rig.family, 'quadruped-canine-v1');
+  assert.equal(genomeApi.selectEmbodiment(genome, 'desktop-companion').interactionProfile, 'desktop-reactive');
+});
+
+test('factory resolves embodiments through swappable adapters', async () => {
+  const factory = new CharacterFactory({ adapters: [
+    createDescriptorAdapter({ id: 'descriptor-3d', kinds: ['game-3d'] }),
+    createDescriptorAdapter({ id: 'descriptor-pet', kinds: ['desktop-companion'] }),
+  ] });
+  const pet = factory.create(desktopOnly);
+  const output = await factory.embody(pet, 'desktop');
+  assert.equal(output.status, 'ready');
+  assert.equal(output.adapter, 'descriptor-pet');
+  assert.equal(output.characterId, 'tiny-companion');
+});
+
+test('invalid wardrobe slots and malformed embodiment ids are rejected', () => {
+  assert.throws(() => genomeApi.normalizeCharacterGenome({ ...humanBase, id: 'bad', wardrobe: { slots: { nonsense: { assetId: 'x' } } } }), genomeApi.CharacterGenomeError);
+  assert.throws(() => genomeApi.normalizeCharacterGenome({ ...humanBase, id: 'bad2', embodiments: [{ id: 'Not Valid', kind: 'pixel' }] }), genomeApi.CharacterGenomeError);
+});


### PR DESCRIPTION
## What changed

- Adds a renderer-agnostic `CharacterGenome` contract for stable character identity, morphology, face/capture confidence metadata, appearance, wardrobe, rig/IK attachments, animation profile, personality, provenance, rights, and multiple embodiments.
- Adds `CharacterFactory` with a swappable embodiment-adapter registry and a descriptor adapter that proves the boundary without coupling the core to Three.js, Pixi, Blender, MetaHuman-like pipelines, or pet packaging.
- Adds contract tests covering five deliberately different fixtures: a photo-derived human, marching trombonist, Archie as a quadruped, Schmalex as a stylized host, and a compact desktop companion.
- Documents the Character Factory v0.1 architecture and keeps Codex/custom-pet compatibility downstream as an adapter concern rather than shaping the core model.

## Why

The project needs one canonical character identity that can survive renderer, art-style, wardrobe, rig, animation backend, and delivery-surface changes. This gives future StadiumSlice performers, JeoPARODY hosts, Archimedes characters, desktop companions, and other embodiments one shared contract instead of parallel character systems.

## Validation

Local isolated contract run: `node --test tests/character-factory.test.mjs`

- 7 tests passed
- 0 failed
- validates identity persistence across embodiments and wardrobe swaps
- validates confidence-aware photo/capture metadata
- validates humanoid and quadruped rig families
- validates adapter resolution and malformed-input rejection

## Next integration step

Build a focused adapter from `CharacterGenome` into the existing `HostAvatarPack` / host performance pipeline, using the real Jeopardish host system as the first renderer integration before expanding toward StadiumSlice performers.