### PR TITLE
Bridge CharacterGenome into the existing HostAvatar pipeline

### DIFF
--- a/src/character/host-avatar-adapter.js
+++ b/src/character/host-avatar-adapter.js
@@ -1,0 +1,127 @@
+(function initCharacterHostAvatarAdapter(root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(
+      require('./character-genome.js'),
+      require('../host/host-avatar.js'),
+    );
+  } else {
+    root.UinverseCharacterHostAvatarAdapter = factory(
+      root.UinverseCharacterGenome,
+      root.JeoPARODYHostAvatar,
+    );
+  }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function characterHostAvatarAdapterFactory(genomeApi, hostAvatarApi) {
+  'use strict';
+
+  const SUPPORTED_KINDS = Object.freeze(['pixel', 'sprite-2d', 'portrait']);
+
+  function wardrobeLabel(item) {
+    if (!item) return '';
+    return [item.assetId, item.variant, item.materialPreset].filter(Boolean).join(' · ');
+  }
+
+  function accessoryLabels(wardrobe) {
+    return Object.entries(wardrobe?.slots || {})
+      .filter(([slot]) => ['head', 'face', 'eyes', 'ears', 'neck', 'hands', 'waist', 'back', 'left-hand', 'right-hand'].includes(slot))
+      .map(([slot, item]) => `${slot}: ${wardrobeLabel(item)}`)
+      .filter(Boolean);
+  }
+
+  function buildPerformanceInventory(genome, embodiment) {
+    return [...new Set([
+      'idle',
+      genome.animation.locomotionSet,
+      ...genome.animation.performanceSets,
+      ...embodiment.animationSet,
+    ].filter(Boolean))].map((id) => ({
+      id: String(id).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'idle',
+      label: String(id).replace(/[-_]+/g, ' '),
+      status: 'runtime',
+    }));
+  }
+
+  function toHostAvatarPack(genomeInput, embodimentIdOrKind, options = {}) {
+    const genome = genomeInput?.schema
+      ? genomeInput
+      : genomeApi.normalizeCharacterGenome(genomeInput);
+    const embodiment = genomeApi.selectEmbodiment(genome, embodimentIdOrKind);
+    if (!embodiment) throw new Error(`Unknown embodiment: ${embodimentIdOrKind}`);
+    if (!SUPPORTED_KINDS.includes(embodiment.kind)) {
+      throw new Error(`HostAvatar adapter does not support embodiment kind: ${embodiment.kind}`);
+    }
+    if (!embodiment.representationAssetId.startsWith('assets/')) {
+      throw new Error('HostAvatar embodiments require a project-local assets/ representation');
+    }
+
+    const shirt = genome.wardrobe.slots.shirt || genome.wardrobe.slots.outerwear;
+    const legs = genome.wardrobe.slots.legs || genome.wardrobe.slots.waist;
+    const lookId = options.lookId || embodiment.id;
+    const performancePoses = buildPerformanceInventory(genome, embodiment);
+
+    return hostAvatarApi.normalizeHostAvatarPack({
+      id: options.packId || `${genome.id}-${embodiment.id}`,
+      hostId: options.hostId || genome.id,
+      displayName: options.displayName || genome.displayName,
+      style: {
+        family: options.styleFamily || genome.appearance.materialProfile || 'CharacterGenome embodiment',
+        pixelScale: options.pixelScale || (embodiment.kind === 'pixel' ? 'character-genome-pixel' : 'character-genome-sprite'),
+        paletteId: options.paletteId || genome.appearance.skinProfile || '',
+      },
+      slots: options.slots,
+      anchors: options.anchors,
+      creation: {
+        editable: true,
+        source: genome.provenance.source,
+        modelFamily: genome.provenance.generator,
+        promptVersion: genome.provenance.generatorVersion,
+        sourceAsset: embodiment.representationAssetId,
+      },
+      rights: genome.rights,
+      inventory: {
+        boardShorts: options.boardShorts || [],
+        specialLooks: options.specialLooks || [],
+        performancePoses,
+      },
+      looks: [{
+        id: lookId,
+        label: options.lookLabel || genome.displayName,
+        frame: options.frame || 'full',
+        weight: options.weight || 1,
+        rarity: options.rarity || 'signature',
+        src: embodiment.representationAssetId,
+        wardrobe: {
+          shorts: wardrobeLabel(legs),
+          shirt: wardrobeLabel(shirt),
+          accessories: accessoryLabels(genome.wardrobe),
+        },
+        eyewear: options.eyewear || {},
+      }],
+    });
+  }
+
+  function createHostAvatarAdapter(options = {}) {
+    return {
+      id: options.id || 'jeoparody-host-avatar',
+      canHandle({ embodiment }) {
+        return SUPPORTED_KINDS.includes(embodiment.kind)
+          && embodiment.representationAssetId.startsWith('assets/');
+      },
+      async build({ genome, embodiment, context }) {
+        const pack = toHostAvatarPack(genome, embodiment.id, context?.hostAvatar || options);
+        return Object.freeze({
+          status: 'ready',
+          adapter: options.id || 'jeoparody-host-avatar',
+          characterId: genome.id,
+          embodimentId: embodiment.id,
+          hostAvatarPack: pack,
+        });
+      },
+    };
+  }
+
+  return {
+    SUPPORTED_KINDS,
+    createHostAvatarAdapter,
+    toHostAvatarPack,
+  };
+}));

--- a/tests/character-host-avatar-adapter.test.mjs
+++ b/tests/character-host-avatar-adapter.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { CharacterFactory } = require('../src/character/character-factory.js');
+const { createHostAvatarAdapter, toHostAvatarPack } = require('../src/character/host-avatar-adapter.js');
+
+const hostGenome = {
+  id: 'schmalex-letrec',
+  displayName: 'Schmalex LeTrec',
+  identity: { archetype: 'beach-game-show-host' },
+  appearance: { materialProfile: 'premium-pixel', skinProfile: 'channel-o-neon-surf' },
+  wardrobe: {
+    slots: {
+      shirt: { assetId: 'garment.hot-pink-camp-shirt' },
+      legs: { assetId: 'garment.broadcast-grid-board-shorts' },
+      eyes: { assetId: 'accessory.yellow-wayfarers' },
+      neck: { assetId: 'accessory.gold-chain' },
+    },
+  },
+  rig: { family: 'humanoid-v1' },
+  animation: {
+    locomotionSet: 'host-idle',
+    performanceSets: ['clue', 'correct', 'incorrect', 'reveal'],
+  },
+  embodiments: [{
+    id: 'broadcast-pixel',
+    kind: 'pixel',
+    renderer: 'sprite',
+    representationAssetId: 'assets/hosts/xander/v1/looks/broadcast-grid-black.png',
+    animationSet: ['streak'],
+  }],
+  provenance: { source: 'authored', generator: 'character-factory', generatorVersion: '1' },
+  rights: { status: 'prototype-original-review-required', notes: 'Review before commercial release.' },
+};
+
+test('CharacterGenome pixel embodiment maps into HostAvatarPack', () => {
+  const pack = toHostAvatarPack(hostGenome, 'broadcast-pixel');
+  assert.equal(pack.schema, 'jeoparody.host-avatar');
+  assert.equal(pack.hostId, 'schmalex-letrec');
+  assert.equal(pack.looks[0].visuals.idle, 'assets/hosts/xander/v1/looks/broadcast-grid-black.png');
+  assert.match(pack.looks[0].wardrobe.shirt, /hot-pink-camp-shirt/);
+  assert.ok(pack.inventory.performancePoses.some(({ id }) => id === 'clue'));
+  assert.equal(pack.rights.status, 'prototype-original-review-required');
+});
+
+test('adapter plugs into CharacterFactory without changing the genome contract', async () => {
+  const factory = new CharacterFactory({ adapters: [createHostAvatarAdapter()] });
+  const genome = factory.create(hostGenome);
+  const output = await factory.embody(genome, 'broadcast-pixel');
+  assert.equal(output.status, 'ready');
+  assert.equal(output.characterId, 'schmalex-letrec');
+  assert.equal(output.hostAvatarPack.hostId, genome.id);
+});
+
+test('host adapter rejects 3D embodiments and non-project asset references', () => {
+  const threeD = { ...hostGenome, id: 'three-d', embodiments: [{ id: 'stage', kind: 'game-3d', representationAssetId: 'assets/model.glb' }] };
+  assert.throws(() => toHostAvatarPack(threeD, 'stage'), /does not support/);
+
+  const remote = { ...hostGenome, id: 'remote', embodiments: [{ id: 'pixel', kind: 'pixel', representationAssetId: 'https://example.com/host.png' }] };
+  assert.throws(() => toHostAvatarPack(remote, 'pixel'), /project-local/);
+});


### PR DESCRIPTION
## What changed

- Adds a focused `CharacterGenome -> HostAvatarPack` adapter instead of introducing a parallel character renderer.
- Maps semantic wardrobe slots, performance sets, provenance, rights metadata, and a pixel/sprite/portrait embodiment into the existing normalized HostAvatar contract.
- Keeps project-local asset safety intact: HostAvatar-bound embodiments must resolve to `assets/` paths.
- Registers cleanly with `CharacterFactory` as a swappable embodiment adapter.
- Adds integration tests for real HostAvatar normalization, factory resolution, unsupported 3D embodiments, and unsafe asset references.

## Architectural intent

This is the first proof that the new canonical identity layer can drive an existing production system without owning its renderer. The HostAvatar system stays responsible for host-specific runtime presentation; CharacterGenome stays responsible for durable identity and semantic character data.

## Validation

The adapter logic passes an isolated 3-test harness locally. This stacked PR also relies on the repository's GitHub Actions suite to validate it against the real `src/host/host-avatar.js` implementation.

## Dependency

Stacked on #56 (`agent/character-genome-v1`). Merge/rebase this after the Character Genome v1 contract lands.

## Next step

Use this seam to generalize the smallest reusable performance vocabulary shared by host avatars and StadiumSlice performers: semantic states, attachment targets, and animation modifiers, without prematurely importing a 3D animation framework.