### PR TITLE
Add renderer-neutral Character Performance vocabulary v1

### DIFF
--- a/docs/CHARACTER_PERFORMANCE_VOCABULARY.md
+++ b/docs/CHARACTER_PERFORMANCE_VOCABULARY.md
@@ -1,0 +1,71 @@
+# Character Performance Vocabulary v0.1
+
+## Goal
+
+Define character performance as semantic intent that can be interpreted by different rigs, renderers, animation systems, and embodiments.
+
+A gameplay system should be able to request `march`, `play-instrument`, `celebrate`, or `suspicious-stare` without knowing whether the result is skeletal animation, procedural IK, sprite states, CSS motion, or a compact desktop-companion behavior.
+
+## Contract
+
+A `PerformanceCommand` contains:
+
+- `kind`: locomotion, action, reaction, pose, or transition
+- `action`: semantic verb/state such as `march`, `play-instrument`, `present-clue`, or `suspicious-stare`
+- optional target
+- loop and duration intent
+- blend mode: replace, additive, upper-body, or facial
+- normalized intensity/speed modifiers
+- optional overrides for stride, posture, energy, looseness, and expressiveness
+- semantic attachments to canonical character targets
+- optional cues and bounded authoring metadata
+
+The contract intentionally contains no renderer, clip name, bone index, keyframe data, shader, or engine-specific object.
+
+## Character defaults
+
+`resolvePerformance()` combines a command with the Character Genome. Missing motion modifiers inherit the character's animation profile. This allows the same `march` command to feel different for a rigid ceremonial performer, a loose parade marcher, or a chaotic cartoon character while keeping the gameplay verb stable.
+
+## Attachments
+
+Performance attachments use semantic targets such as `left-hand`, `right-hand`, `mouth`, `back`, and `tail-base`.
+
+When resolved against a Character Genome, each semantic attachment is paired with the character's rig anchor if one exists. A later animation/IK adapter decides how to satisfy that contact or grip.
+
+Example marching trombone performance:
+
+```js
+resolvePerformance(trombonist, {
+  kind: 'action',
+  action: 'play-instrument',
+  blend: 'upper-body',
+  attachments: [
+    { target: 'left-hand', itemId: 'instrument.trombone', grip: 'brace' },
+    { target: 'right-hand', itemId: 'instrument.trombone', grip: 'slide' },
+  ],
+});
+```
+
+This is enough information for a future instrument adapter to solve grip placement and for a motion adapter to layer the performance over marching locomotion.
+
+## Parallel performance
+
+The `upper-body` and `facial` blend modes are the first deliberately small seam for simultaneous behaviors. A marching musician can run looping `march` locomotion while an upper-body `play-instrument` action controls hands, arms, chest, and mouth.
+
+The core does not perform blending itself. It communicates intent to an implementation that can.
+
+## Why sequences exist
+
+`createPerformanceSequence()` preserves authored order for cinematics, scripted beats, tutorials, sports drills, host performances, and compact NPC behavior. Timing engines remain downstream.
+
+## StadiumSlice target
+
+The next practical implementation should use this vocabulary to model one marching performer:
+
+1. resolve a looping `march` locomotion command
+2. resolve an upper-body `play-instrument` command
+3. attach a trombone to left/right semantic hand targets
+4. add a mouth contact target where the rig supports it
+5. feed those resolved commands into a thin 3D animation/IK adapter
+
+That slice will reveal what the 3D adapter actually needs instead of guessing in advance.

--- a/src/character/performance-command.js
+++ b/src/character/performance-command.js
@@ -1,0 +1,141 @@
+(function initPerformanceCommand(root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory(require('./character-genome.js'));
+  else root.UinversePerformanceCommand = factory(root.UinverseCharacterGenome);
+}(typeof globalThis !== 'undefined' ? globalThis : this, function performanceCommandFactory(genomeApi) {
+  'use strict';
+
+  const PERFORMANCE_SCHEMA = 'uinverse.character-performance';
+  const PERFORMANCE_VERSION = 1;
+  const PERFORMANCE_KINDS = Object.freeze(['locomotion', 'action', 'reaction', 'pose', 'transition']);
+  const BLEND_MODES = Object.freeze(['replace', 'additive', 'upper-body', 'facial']);
+
+  class PerformanceCommandError extends Error {
+    constructor(issues) {
+      super(`Invalid PerformanceCommand: ${issues.join('; ')}`);
+      this.name = 'PerformanceCommandError';
+      this.issues = Object.freeze([...issues]);
+    }
+  }
+
+  function deepFreeze(value) {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+    Object.values(value).forEach(deepFreeze);
+    return Object.freeze(value);
+  }
+
+  function cleanText(value, maxLength = 120) {
+    return String(value || '').replace(/\s+/g, ' ').trim().slice(0, maxLength);
+  }
+
+  function semanticId(value) {
+    return cleanText(value, 100).toLowerCase().replace(/[^a-z0-9:.-]+/g, '-').replace(/^-|-$/g, '');
+  }
+
+  function clamp01(value, fallback = 0.5) {
+    const n = Number(value);
+    return Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : fallback;
+  }
+
+  function normalizeAttachment(input, index, issues) {
+    const target = cleanText(input?.target, 100);
+    if (!genomeApi.ATTACHMENT_TARGETS.includes(target) && !target.startsWith('custom:')) {
+      issues.push(`attachments[${index}].target is unsupported`);
+    }
+    const itemId = cleanText(input?.itemId, 140);
+    if (!itemId) issues.push(`attachments[${index}].itemId is required`);
+    return {
+      target,
+      itemId,
+      mode: ['hold', 'wear', 'mount', 'contact'].includes(input?.mode) ? input.mode : 'hold',
+      grip: semanticId(input?.grip),
+    };
+  }
+
+  function normalizePerformanceCommand(input = {}) {
+    const issues = [];
+    const kind = PERFORMANCE_KINDS.includes(input.kind) ? input.kind : '';
+    if (!kind) issues.push('kind is unsupported');
+    const action = semanticId(input.action || input.verb);
+    if (!action) issues.push('action is required');
+    const attachments = Array.isArray(input.attachments)
+      ? input.attachments.map((item, index) => normalizeAttachment(item, index, issues))
+      : [];
+
+    const result = {
+      schema: PERFORMANCE_SCHEMA,
+      version: PERFORMANCE_VERSION,
+      id: semanticId(input.id || `${kind || 'performance'}:${action || 'unknown'}`),
+      kind,
+      action,
+      target: semanticId(input.target),
+      loop: input.loop === true,
+      durationMs: Number.isFinite(Number(input.durationMs)) ? Math.max(0, Number(input.durationMs)) : 0,
+      blend: BLEND_MODES.includes(input.blend) ? input.blend : 'replace',
+      modifiers: {
+        intensity: clamp01(input.modifiers?.intensity, 0.5),
+        speed: clamp01(input.modifiers?.speed, 0.5),
+        stride: input.modifiers?.stride == null ? null : clamp01(input.modifiers.stride),
+        posture: input.modifiers?.posture == null ? null : clamp01(input.modifiers.posture),
+        energy: input.modifiers?.energy == null ? null : clamp01(input.modifiers.energy),
+        looseness: input.modifiers?.looseness == null ? null : clamp01(input.modifiers.looseness),
+        expressiveness: input.modifiers?.expressiveness == null ? null : clamp01(input.modifiers.expressiveness),
+      },
+      attachments,
+      cues: Array.isArray(input.cues) ? input.cues.map((cue) => semanticId(cue)).filter(Boolean) : [],
+      metadata: {
+        source: cleanText(input.metadata?.source, 80) || 'authored',
+        note: cleanText(input.metadata?.note, 240),
+      },
+    };
+
+    if (issues.length) throw new PerformanceCommandError(issues);
+    return deepFreeze(result);
+  }
+
+  function resolvePerformance(genomeInput, commandInput) {
+    const genome = genomeInput?.schema === genomeApi.CHARACTER_SCHEMA
+      ? genomeInput
+      : genomeApi.normalizeCharacterGenome(genomeInput);
+    const command = commandInput?.schema === PERFORMANCE_SCHEMA
+      ? commandInput
+      : normalizePerformanceCommand(commandInput);
+    const defaults = genome.animation?.modifiers || {};
+    const modifiers = {};
+    ['stride', 'posture', 'energy', 'looseness', 'expressiveness'].forEach((key) => {
+      modifiers[key] = command.modifiers[key] == null ? clamp01(defaults[key], 0.5) : command.modifiers[key];
+    });
+    modifiers.intensity = command.modifiers.intensity;
+    modifiers.speed = command.modifiers.speed;
+
+    return deepFreeze({
+      ...command,
+      characterId: genome.id,
+      rigFamily: genome.rig.family,
+      modifiers,
+      semanticAttachments: command.attachments.map((attachment) => ({
+        ...attachment,
+        rigAnchor: genome.rig.attachments?.[attachment.target] || null,
+      })),
+    });
+  }
+
+  function createPerformanceSequence(items = []) {
+    const commands = items.map((item) => normalizePerformanceCommand(item));
+    return deepFreeze({
+      schema: 'uinverse.performance-sequence',
+      version: 1,
+      commands,
+    });
+  }
+
+  return {
+    BLEND_MODES,
+    PERFORMANCE_KINDS,
+    PERFORMANCE_SCHEMA,
+    PERFORMANCE_VERSION,
+    PerformanceCommandError,
+    createPerformanceSequence,
+    normalizePerformanceCommand,
+    resolvePerformance,
+  };
+}));

--- a/tests/character-performance.test.mjs
+++ b/tests/character-performance.test.mjs
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const genomeApi = require('../src/character/character-genome.js');
+const performanceApi = require('../src/character/performance-command.js');
+
+const trombonist = genomeApi.normalizeCharacterGenome({
+  id: 'marching-trombonist',
+  displayName: 'Marching Trombonist',
+  morphology: { kind: 'humanoid', species: 'human' },
+  rig: {
+    family: 'humanoid-v1',
+    attachments: {
+      'left-hand': { bone: 'hand.L' },
+      'right-hand': { bone: 'hand.R' },
+      mouth: { bone: 'head' },
+    },
+  },
+  animation: {
+    locomotionSet: 'march-standard',
+    performanceSets: ['trombone-performance'],
+    modifiers: { stride: 0.62, posture: 0.76, energy: 0.73, looseness: 0.35, expressiveness: 0.58 },
+  },
+  embodiments: [{ id: 'stadium-3d', kind: 'game-3d', renderer: 'three', representationAssetId: 'model.trombonist' }],
+});
+
+const archie = genomeApi.normalizeCharacterGenome({
+  id: 'archie',
+  displayName: 'Archie',
+  morphology: { kind: 'quadruped', species: 'maltese-mix' },
+  rig: { family: 'quadruped-canine-v1', attachments: { mouth: { bone: 'jaw' }, 'tail-base': { bone: 'tail.01' } } },
+  animation: { locomotionSet: 'small-dog-chaos', performanceSets: ['suspicious-stare'], modifiers: { energy: 0.82, looseness: 0.78, expressiveness: 0.9 } },
+  embodiments: [{ id: 'platformer', kind: 'pixel', renderer: 'sprite', representationAssetId: 'sprite.archie' }],
+});
+
+test('marching performance is semantic and renderer-neutral', () => {
+  const command = performanceApi.normalizePerformanceCommand({
+    kind: 'locomotion',
+    action: 'march',
+    loop: true,
+    modifiers: { intensity: 0.72, speed: 0.58 },
+  });
+  assert.equal(command.schema, performanceApi.PERFORMANCE_SCHEMA);
+  assert.equal(command.action, 'march');
+  assert.equal(command.loop, true);
+  assert.equal('renderer' in command, false);
+  assert.equal(Object.isFrozen(command), true);
+});
+
+test('resolved performance inherits character defaults without mutating the command', () => {
+  const command = performanceApi.normalizePerformanceCommand({ kind: 'action', action: 'play-instrument', modifiers: { intensity: 0.8 } });
+  const resolved = performanceApi.resolvePerformance(trombonist, command);
+  assert.equal(resolved.characterId, 'marching-trombonist');
+  assert.equal(resolved.rigFamily, 'humanoid-v1');
+  assert.equal(resolved.modifiers.posture, 0.76);
+  assert.equal(resolved.modifiers.energy, 0.73);
+  assert.equal(command.modifiers.posture, null);
+});
+
+test('instrument attachments resolve semantic hands into rig anchors', () => {
+  const resolved = performanceApi.resolvePerformance(trombonist, {
+    kind: 'action',
+    action: 'play-instrument',
+    blend: 'upper-body',
+    attachments: [
+      { target: 'left-hand', itemId: 'instrument.trombone', grip: 'brace' },
+      { target: 'right-hand', itemId: 'instrument.trombone', grip: 'slide' },
+    ],
+  });
+  assert.equal(resolved.semanticAttachments[0].rigAnchor.bone, 'hand.L');
+  assert.equal(resolved.semanticAttachments[1].rigAnchor.bone, 'hand.R');
+  assert.equal(resolved.blend, 'upper-body');
+});
+
+test('the same performance contract handles Archie reactions', () => {
+  const resolved = performanceApi.resolvePerformance(archie, {
+    kind: 'reaction',
+    action: 'suspicious-stare',
+    blend: 'facial',
+    modifiers: { intensity: 0.92 },
+  });
+  assert.equal(resolved.characterId, 'archie');
+  assert.equal(resolved.action, 'suspicious-stare');
+  assert.equal(resolved.modifiers.expressiveness, 0.9);
+});
+
+test('performance sequences preserve authored order and freeze commands', () => {
+  const sequence = performanceApi.createPerformanceSequence([
+    { kind: 'locomotion', action: 'march', loop: true },
+    { kind: 'action', action: 'play-instrument', blend: 'upper-body' },
+    { kind: 'reaction', action: 'celebrate' },
+  ]);
+  assert.deepEqual(sequence.commands.map(({ action }) => action), ['march', 'play-instrument', 'celebrate']);
+  assert.equal(Object.isFrozen(sequence.commands[0]), true);
+});
+
+test('invalid kinds and unsupported attachment targets fail early', () => {
+  assert.throws(() => performanceApi.normalizePerformanceCommand({ kind: 'teleportish', action: 'march' }), performanceApi.PerformanceCommandError);
+  assert.throws(() => performanceApi.normalizePerformanceCommand({ kind: 'action', action: 'hold-prop', attachments: [{ target: 'elbow-ish', itemId: 'prop.flag' }] }), performanceApi.PerformanceCommandError);
+});


### PR DESCRIPTION
## What changed

- Adds a versioned, immutable `PerformanceCommand` contract with semantic kinds: locomotion, action, reaction, pose, and transition.
- Adds semantic actions such as `march`, `play-instrument`, and `suspicious-stare` without binding commands to renderers, clips, bones, or animation engines.
- Adds normalized motion modifiers for intensity, speed, stride, posture, energy, looseness, and expressiveness.
- Adds semantic prop/contact attachments that resolve against CharacterGenome rig anchors (`left-hand`, `right-hand`, `mouth`, etc.).
- Adds small blend intent (`replace`, `additive`, `upper-body`, `facial`) so marching locomotion can coexist with an instrument performance without putting animation-engine logic into the core.
- Adds immutable performance sequences for authored/cinematic beats.
- Adds tests covering marching musicians, trombone grips, inherited character motion defaults, Archie reactions, sequence ordering, and malformed commands.
- Documents the StadiumSlice path from semantic performance to a future thin 3D animation/IK adapter.

## Why

The shared universe needs gameplay systems to request what a character should *do* without knowing how a particular renderer or rig realizes it. This lets the same command vocabulary serve Jeopardish hosts, StadiumSlice performers, Archie, desktop companions, sports characters, and future embodiments.

## Dependency

Stacked directly on #56 (`agent/character-genome-v1`) and intentionally independent of #57, so the HostAvatar bridge and performance vocabulary can evolve in parallel.

## Next implementation step

Build one narrow 3D performer adapter for StadiumSlice that consumes two resolved commands concurrently:

1. looping `march` locomotion
2. upper-body `play-instrument` with trombone left/right hand grips and optional mouth contact

That real slice should define the minimum animation/IK adapter contract instead of designing a speculative general-purpose animation framework.