### PR TITLE
Add Stadium marching performer execution-plan adapter

### DIFF
--- a/docs/STADIUM_PERFORMER_SLICE.md
+++ b/docs/STADIUM_PERFORMER_SLICE.md
@@ -1,0 +1,89 @@
+# Stadium Performer Slice v0
+
+## Purpose
+
+Turn Character Genome + semantic Performance Commands into the smallest useful 3D performer execution plan for a marching musician.
+
+This slice deliberately stops before choosing a skeletal-animation or IK library. It tells that future implementation exactly what it must do.
+
+## Input
+
+A Stadium performer requires:
+
+- a humanoid `CharacterGenome`
+- a `game-3d` embodiment
+- looping locomotion, initially `march`
+- an upper-body or additive `play-instrument` action
+- semantic left- and right-hand instrument attachments
+- rig anchors for every requested attachment
+
+Mouth contact is optional at the contract level, but supported when the character and instrument require it.
+
+## Output
+
+`buildStadiumPerformerPlan()` produces an immutable execution plan containing:
+
+- character and embodiment identity
+- renderer hint and model asset ID
+- rig profile
+- base locomotion layer
+- upper-body performance layer
+- canonical instrument props
+- concrete bone/contact constraints resolved from semantic attachments
+- a capability list the eventual runtime must implement
+
+A trombone performance currently advertises capabilities including:
+
+- skeletal animation
+- layered animation
+- root locomotion
+- semantic attachments
+- two-hand prop IK
+- face/head contact when a mouthpiece is attached
+
+## Why this boundary matters
+
+Gameplay owns the verbs. Character Genome owns identity and semantic rig anchors. Performance Commands own behavioral intent. Stadium Performer translates those facts into an implementation plan. The future renderer owns clips, mixers, bones, IK solvers, matrices, scene objects, and frame updates.
+
+No upstream layer needs to know which 3D engine wins that job.
+
+## First performer
+
+The reference performer is a marching trombonist:
+
+```js
+const plan = buildStadiumPerformerPlan({
+  genome: trombonist,
+  locomotion: {
+    kind: 'locomotion',
+    action: 'march',
+    loop: true,
+  },
+  performance: {
+    kind: 'action',
+    action: 'play-instrument',
+    blend: 'upper-body',
+    loop: true,
+    attachments: [
+      { target: 'left-hand', itemId: 'instrument.trombone', grip: 'brace' },
+      { target: 'right-hand', itemId: 'instrument.trombone', grip: 'slide' },
+      { target: 'mouth', itemId: 'instrument.trombone', mode: 'contact', grip: 'mouthpiece' },
+    ],
+  },
+});
+```
+
+The plan contains enough information to keep the feet marching while the upper body plays and the instrument remains constrained to both hands and the mouthpiece contact point.
+
+## Next technical decision
+
+The next branch should implement a thin engine adapter against one actual 3D runtime. Selection criteria should be driven by this plan rather than library fashion:
+
+1. skeletal clip playback and cross-fade
+2. independent upper-body masking/layering
+3. practical two-hand prop IK
+4. stable bone lookup/retarget mapping
+5. acceptable browser bundle/runtime cost
+6. ability to keep the underlying contracts engine-neutral
+
+Before adding a dependency, compare the existing mature options and choose the smallest implementation that can satisfy this exact marching-trombone slice.

--- a/src/character/stadium-performer-adapter.js
+++ b/src/character/stadium-performer-adapter.js
@@ -1,0 +1,171 @@
+(function initStadiumPerformerAdapter(root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(
+      require('./character-genome.js'),
+      require('./performance-command.js'),
+    );
+  } else {
+    root.UinverseStadiumPerformerAdapter = factory(
+      root.UinverseCharacterGenome,
+      root.UinversePerformanceCommand,
+    );
+  }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function stadiumPerformerAdapterFactory(genomeApi, performanceApi) {
+  'use strict';
+
+  const STADIUM_PLAN_SCHEMA = 'uinverse.stadium-performer-plan';
+  const STADIUM_PLAN_VERSION = 1;
+
+  class StadiumPerformerError extends Error {
+    constructor(issues) {
+      super(`Invalid StadiumPerformerPlan: ${issues.join('; ')}`);
+      this.name = 'StadiumPerformerError';
+      this.issues = Object.freeze([...issues]);
+    }
+  }
+
+  function deepFreeze(value) {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+    Object.values(value).forEach(deepFreeze);
+    return Object.freeze(value);
+  }
+
+  function resolveCommand(genome, input) {
+    return input?.schema === performanceApi.PERFORMANCE_SCHEMA
+      ? performanceApi.resolvePerformance(genome, input)
+      : performanceApi.resolvePerformance(genome, input || {});
+  }
+
+  function validateInstrumentPerformance(command, issues) {
+    if (command.kind !== 'action') issues.push('instrument performance must be an action');
+    if (command.action !== 'play-instrument') issues.push('instrument performance action must be play-instrument');
+    if (command.blend !== 'upper-body' && command.blend !== 'additive') {
+      issues.push('instrument performance must use upper-body or additive blend');
+    }
+    const targets = new Set(command.semanticAttachments.map(({ target }) => target));
+    if (!targets.has('left-hand')) issues.push('instrument performance requires left-hand attachment');
+    if (!targets.has('right-hand')) issues.push('instrument performance requires right-hand attachment');
+  }
+
+  function buildConstraint(attachment, issues) {
+    if (!attachment.rigAnchor?.bone) {
+      issues.push(`missing rig anchor for ${attachment.target}`);
+      return null;
+    }
+    return {
+      type: attachment.mode === 'contact' ? 'contact' : 'attachment',
+      target: attachment.target,
+      bone: attachment.rigAnchor.bone,
+      itemId: attachment.itemId,
+      grip: attachment.grip,
+      localPosition: attachment.rigAnchor.position || [0, 0, 0],
+      localRotation: attachment.rigAnchor.rotation || [0, 0, 0],
+    };
+  }
+
+  function buildStadiumPerformerPlan({
+    genome: genomeInput,
+    embodiment: embodimentIdOrKind = 'game-3d',
+    locomotion,
+    performance,
+  } = {}) {
+    const issues = [];
+    const genome = genomeInput?.schema === genomeApi.CHARACTER_SCHEMA
+      ? genomeInput
+      : genomeApi.normalizeCharacterGenome(genomeInput || {});
+    const selected = genomeApi.selectEmbodiment(genome, embodimentIdOrKind);
+
+    if (!selected) issues.push(`unknown embodiment: ${embodimentIdOrKind}`);
+    else if (selected.kind !== 'game-3d') issues.push('stadium performer requires a game-3d embodiment');
+    if (genome.morphology.kind !== 'humanoid') issues.push('stadium performer v0 supports humanoid morphology only');
+
+    let locomotionCommand = null;
+    let performanceCommand = null;
+    if (!issues.length) {
+      locomotionCommand = resolveCommand(genome, locomotion);
+      performanceCommand = resolveCommand(genome, performance);
+      if (locomotionCommand.kind !== 'locomotion') issues.push('base command must be locomotion');
+      if (!locomotionCommand.loop) issues.push('stadium locomotion must be loopable');
+      validateInstrumentPerformance(performanceCommand, issues);
+    }
+
+    const constraints = [];
+    if (performanceCommand) {
+      performanceCommand.semanticAttachments.forEach((attachment) => {
+        const constraint = buildConstraint(attachment, issues);
+        if (constraint) constraints.push(constraint);
+      });
+    }
+
+    if (issues.length) throw new StadiumPerformerError(issues);
+
+    const instrumentIds = [...new Set(constraints.map(({ itemId }) => itemId).filter(Boolean))];
+    const requiredCapabilities = ['skeletal-animation', 'layered-animation', 'root-locomotion'];
+    if (constraints.length) requiredCapabilities.push('semantic-attachments');
+    if (constraints.some(({ target }) => target.includes('hand'))) requiredCapabilities.push('two-hand-prop-ik');
+    if (constraints.some(({ target }) => target === 'mouth')) requiredCapabilities.push('face-or-head-contact');
+
+    return deepFreeze({
+      schema: STADIUM_PLAN_SCHEMA,
+      version: STADIUM_PLAN_VERSION,
+      characterId: genome.id,
+      embodimentId: selected.id,
+      rendererHint: selected.renderer || 'three',
+      modelAssetId: selected.representationAssetId,
+      rigProfile: selected.rigProfile || genome.rig.family,
+      layers: [
+        {
+          id: 'base-locomotion',
+          kind: locomotionCommand.kind,
+          action: locomotionCommand.action,
+          blend: 'replace',
+          loop: locomotionCommand.loop,
+          modifiers: locomotionCommand.modifiers,
+        },
+        {
+          id: 'upper-body-performance',
+          kind: performanceCommand.kind,
+          action: performanceCommand.action,
+          blend: performanceCommand.blend,
+          loop: performanceCommand.loop,
+          modifiers: performanceCommand.modifiers,
+        },
+      ],
+      props: instrumentIds.map((itemId) => ({ itemId, role: 'instrument' })),
+      constraints,
+      requiredCapabilities: [...new Set(requiredCapabilities)],
+    });
+  }
+
+  function createStadiumPerformerAdapter(options = {}) {
+    return {
+      id: options.id || 'stadium-performer-v0',
+      canHandle({ genome, embodiment }) {
+        return genome.morphology.kind === 'humanoid' && embodiment.kind === 'game-3d';
+      },
+      async build({ genome, embodiment, context = {} }) {
+        const plan = buildStadiumPerformerPlan({
+          genome,
+          embodiment: embodiment.id,
+          locomotion: context.locomotion,
+          performance: context.performance,
+        });
+        return Object.freeze({
+          status: 'ready',
+          adapter: options.id || 'stadium-performer-v0',
+          characterId: genome.id,
+          embodimentId: embodiment.id,
+          plan,
+        });
+      },
+    };
+  }
+
+  return {
+    STADIUM_PLAN_SCHEMA,
+    STADIUM_PLAN_VERSION,
+    StadiumPerformerError,
+    buildStadiumPerformerPlan,
+    createStadiumPerformerAdapter,
+  };
+}));

--- a/tests/stadium-performer-adapter.test.mjs
+++ b/tests/stadium-performer-adapter.test.mjs
@@ -1,0 +1,132 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const genomeApi = require('../src/character/character-genome.js');
+const { CharacterFactory } = require('../src/character/character-factory.js');
+const performanceApi = require('../src/character/performance-command.js');
+const {
+  STADIUM_PLAN_SCHEMA,
+  StadiumPerformerError,
+  buildStadiumPerformerPlan,
+  createStadiumPerformerAdapter,
+} = require('../src/character/stadium-performer-adapter.js');
+
+const performer = genomeApi.normalizeCharacterGenome({
+  id: 'stadium-trombonist',
+  displayName: 'Stadium Trombonist',
+  morphology: { kind: 'humanoid', species: 'human' },
+  rig: {
+    family: 'humanoid-v1',
+    attachments: {
+      'left-hand': { bone: 'hand.L', position: [0.02, 0, 0] },
+      'right-hand': { bone: 'hand.R', position: [0.01, 0, 0] },
+      mouth: { bone: 'head', position: [0, 0.08, 0.11] },
+    },
+  },
+  animation: {
+    locomotionSet: 'march-standard',
+    performanceSets: ['trombone-performance'],
+    modifiers: { stride: 0.62, posture: 0.76, energy: 0.73, looseness: 0.35, expressiveness: 0.58 },
+  },
+  embodiments: [{
+    id: 'stadium-3d',
+    kind: 'game-3d',
+    renderer: 'three',
+    representationAssetId: 'model.stadium-trombonist',
+    rigProfile: 'humanoid-v1',
+  }],
+});
+
+const march = performanceApi.normalizePerformanceCommand({
+  kind: 'locomotion',
+  action: 'march',
+  loop: true,
+  modifiers: { speed: 0.6, intensity: 0.72 },
+});
+
+const playTrombone = performanceApi.normalizePerformanceCommand({
+  kind: 'action',
+  action: 'play-instrument',
+  blend: 'upper-body',
+  loop: true,
+  modifiers: { intensity: 0.8 },
+  attachments: [
+    { target: 'left-hand', itemId: 'instrument.trombone', grip: 'brace' },
+    { target: 'right-hand', itemId: 'instrument.trombone', grip: 'slide' },
+    { target: 'mouth', itemId: 'instrument.trombone', mode: 'contact', grip: 'mouthpiece' },
+  ],
+});
+
+test('stadium plan layers marching locomotion and upper-body instrument performance', () => {
+  const plan = buildStadiumPerformerPlan({ genome: performer, locomotion: march, performance: playTrombone });
+  assert.equal(plan.schema, STADIUM_PLAN_SCHEMA);
+  assert.equal(plan.characterId, 'stadium-trombonist');
+  assert.equal(plan.layers[0].action, 'march');
+  assert.equal(plan.layers[0].blend, 'replace');
+  assert.equal(plan.layers[1].action, 'play-instrument');
+  assert.equal(plan.layers[1].blend, 'upper-body');
+  assert.equal(plan.props[0].itemId, 'instrument.trombone');
+  assert.equal(Object.isFrozen(plan), true);
+});
+
+test('semantic grips become concrete rig constraints without engine objects', () => {
+  const plan = buildStadiumPerformerPlan({ genome: performer, locomotion: march, performance: playTrombone });
+  const left = plan.constraints.find(({ target }) => target === 'left-hand');
+  const right = plan.constraints.find(({ target }) => target === 'right-hand');
+  const mouth = plan.constraints.find(({ target }) => target === 'mouth');
+  assert.equal(left.bone, 'hand.L');
+  assert.equal(right.bone, 'hand.R');
+  assert.equal(mouth.type, 'contact');
+  assert.equal(mouth.bone, 'head');
+  assert.equal('object3D' in plan, false);
+  assert.equal('mixer' in plan, false);
+});
+
+test('plan advertises implementation capabilities learned from the real slice', () => {
+  const plan = buildStadiumPerformerPlan({ genome: performer, locomotion: march, performance: playTrombone });
+  assert.ok(plan.requiredCapabilities.includes('layered-animation'));
+  assert.ok(plan.requiredCapabilities.includes('two-hand-prop-ik'));
+  assert.ok(plan.requiredCapabilities.includes('face-or-head-contact'));
+});
+
+test('CharacterFactory can resolve a 3D performer through the stadium adapter', async () => {
+  const factory = new CharacterFactory({ adapters: [createStadiumPerformerAdapter()] });
+  const output = await factory.embody(performer, 'stadium-3d', {
+    locomotion: march,
+    performance: playTrombone,
+  });
+  assert.equal(output.status, 'ready');
+  assert.equal(output.adapter, 'stadium-performer-v0');
+  assert.equal(output.plan.layers.length, 2);
+});
+
+test('v0 rejects non-humanoid performers and incomplete two-hand instrument rigs', () => {
+  const dog = genomeApi.normalizeCharacterGenome({
+    id: 'stadium-dog',
+    displayName: 'Stadium Dog',
+    morphology: { kind: 'quadruped', species: 'dog' },
+    rig: { family: 'canine-v1', attachments: { mouth: { bone: 'jaw' } } },
+    animation: { locomotionSet: 'run' },
+    embodiments: [{ id: 'stadium-3d', kind: 'game-3d', representationAssetId: 'model.dog' }],
+  });
+  assert.throws(() => buildStadiumPerformerPlan({ genome: dog, locomotion: march, performance: playTrombone }), StadiumPerformerError);
+
+  const oneHand = performanceApi.normalizePerformanceCommand({
+    kind: 'action', action: 'play-instrument', blend: 'upper-body',
+    attachments: [{ target: 'left-hand', itemId: 'instrument.trombone' }],
+  });
+  assert.throws(() => buildStadiumPerformerPlan({ genome: performer, locomotion: march, performance: oneHand }), StadiumPerformerError);
+});
+
+test('missing rig anchors fail before a renderer gets an impossible assignment', () => {
+  const badRig = genomeApi.normalizeCharacterGenome({
+    id: 'bad-rig-trombonist',
+    displayName: 'Bad Rig Trombonist',
+    morphology: { kind: 'humanoid', species: 'human' },
+    rig: { family: 'humanoid-v1', attachments: { 'left-hand': { bone: 'hand.L' } } },
+    animation: { locomotionSet: 'march-standard' },
+    embodiments: [{ id: 'stadium-3d', kind: 'game-3d', representationAssetId: 'model.bad' }],
+  });
+  assert.throws(() => buildStadiumPerformerPlan({ genome: badRig, locomotion: march, performance: playTrombone }), /missing rig anchor for right-hand/);
+});


### PR DESCRIPTION
## What changed

- Adds a narrow Stadium performer adapter on top of CharacterGenome + PerformanceCommand.
- Converts one `game-3d` humanoid embodiment plus looping locomotion and an upper-body `play-instrument` command into an immutable execution plan.
- Resolves semantic left/right hand and optional mouth attachments into concrete rig constraints before any renderer runs.
- Emits two explicit animation layers: base locomotion and upper-body performance.
- Extracts the instrument prop once and advertises capabilities the eventual 3D runtime must satisfy, including layered animation, two-hand prop IK, and face/head contact.
- Fails early for non-humanoid performers, incomplete two-hand instrument commands, and missing rig anchors.
- Adds six tests around the marching-trombone slice and documents the boundary for the eventual engine-specific adapter.

## Why

This turns the StadiumSlice idea into a real contract test rather than choosing a 3D framework first and reverse-engineering our architecture around it. We now know the first runtime must support a marching base layer, upper-body instrument performance, semantic attachment resolution, and two-hand prop constraints.

## Dependency

Stacked on #58 (`agent/character-performance-v1`), which is stacked on #56. It is intentionally independent of the HostAvatar bridge in #57.

## Next step

Research the smallest mature browser 3D animation/IK implementation that satisfies this exact execution plan, then build one thin adapter against it. No engine dependency should leak upstream into CharacterGenome or PerformanceCommand.