### PR TITLE
Add injected Three.js Stadium runtime adapter

### DIFF
--- a/docs/THREE_STADIUM_RUNTIME_DECISION.md
+++ b/docs/THREE_STADIUM_RUNTIME_DECISION.md
@@ -1,0 +1,77 @@
+# Three.js Stadium Runtime Decision v0
+
+## Decision
+
+Use Three.js as the first StadiumSlice browser runtime behind an injected adapter. Do not import Three.js into CharacterGenome, PerformanceCommand, or StadiumPerformerPlan.
+
+The v0 implementation accepts the Three namespace and `CCDIKSolver` constructor as dependencies so the engine remains replaceable and the current static application does not need a new production dependency merely to prove the architecture.
+
+## Requirements discovered by the marching-trombone slice
+
+The runtime must provide:
+
+1. skeletal animation clip playback
+2. simultaneous weighted/layered actions
+3. an upper-body-only instrument clip
+4. two-hand inverse kinematics for a shared prop
+5. optional head/mouth contact
+6. stable frame ordering: animation first, IK second
+7. bounded frame deltas so tab suspension does not create giant simulation jumps
+
+## Why Three.js first
+
+Three.js has a compact animation foundation centered on `AnimationMixer`, `AnimationAction`, and `AnimationClip`. Multiple actions can be active and weighted at once. The official addon set also contains `CCDIKSolver` for inverse-kinematics chains on skinned meshes.
+
+Three.js does not provide the same first-class animation-layer mask authoring model as PlayCanvas. For this slice that gap is small: `AnimationClip` consists of named keyframe tracks, so the adapter derives an upper-body clip by retaining only tracks targeting an explicitly supplied upper-body bone set.
+
+This keeps masking logic local to the Three adapter instead of teaching the engine-neutral performance contract about skeleton paths.
+
+## Alternatives considered
+
+### PlayCanvas
+
+PlayCanvas has excellent native animation layers, weights, and bone masks. It maps cleanly to the base-march + upper-body-performance model. For this exact slice, however, the official animation surface solves the layering problem more directly than the two-hand IK problem. It remains a strong alternate implementation behind the same StadiumPerformerPlan.
+
+### Babylon.js
+
+Babylon.js provides `BoneIKController` and a broad game-engine surface. It can satisfy the IK side of the slice directly, but adopting the broader engine before the proving slice requires it would increase coupling and migration cost. It remains a viable future adapter if its higher-level systems become advantageous elsewhere in uINVERSE.
+
+## v0 adapter responsibilities
+
+`ThreeStadiumRuntime`:
+
+- resolves semantic layer actions to actual model clips through an injected `clipResolver`
+- creates one `AnimationMixer`
+- plays the full-body base locomotion clip
+- derives and plays a masked upper-body performance clip
+- delegates model-specific CCD chain construction to an injected `ikResolver`
+- updates the animation mixer before the IK solver
+- clamps large frame deltas
+- disposes mixer state cleanly
+
+## Deliberate omissions
+
+The adapter does not yet:
+
+- load GLTF assets
+- define a canonical humanoid bone-name map
+- construct CCD target bones automatically
+- place or animate the trombone prop itself
+- retarget clips between skeletons
+- solve formation movement
+- render a scene
+
+Those should be added only as the real Stadium slice needs them.
+
+## Official references
+
+- Three.js AnimationMixer: https://threejs.org/docs/pages/AnimationMixer.html
+- Three.js AnimationAction: https://threejs.org/docs/pages/AnimationAction.html
+- Three.js animation system: https://threejs.org/manual/en/animation-system.html
+- Three.js CCDIKSolver: https://threejs.org/docs/pages/CCDIKSolver.html
+- PlayCanvas animation layer masking: https://developer.playcanvas.com/user-manual/animation/anim-layer-masking/
+- Babylon.js BoneIKController: https://doc.babylonjs.com/typedoc/classes/_babylonjs_core.BoneIKController
+
+## Next proving step
+
+Create one tiny GLTF fixture with a humanoid skeleton, named `march` and `play-instrument` clips, explicit left/right hand IK chains, and a trombone prop. Then mount this runtime against the real Three.js classes in a visual fixture. That test should be the point where Three.js becomes an actual runtime dependency, if the slice still justifies it.

--- a/src/character/three-stadium-runtime.js
+++ b/src/character/three-stadium-runtime.js
@@ -1,0 +1,128 @@
+(function initThreeStadiumRuntime(root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.UinverseThreeStadiumRuntime = factory();
+}(typeof globalThis !== 'undefined' ? globalThis : this, function threeStadiumRuntimeFactory() {
+  'use strict';
+
+  class ThreeStadiumRuntimeError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = 'ThreeStadiumRuntimeError';
+    }
+  }
+
+  function trackTargetsBone(trackName, boneNames) {
+    const name = String(trackName || '');
+    return boneNames.some((bone) => name.includes(`bones[${bone}]`) || name.includes(`.${bone}.`) || name.endsWith(`.${bone}`));
+  }
+
+  function maskAnimationClip(THREE, clip, boneNames = []) {
+    if (!clip || !Array.isArray(clip.tracks)) throw new ThreeStadiumRuntimeError('animation clip with tracks is required');
+    if (!boneNames.length) throw new ThreeStadiumRuntimeError('upper-body bone mask requires at least one bone');
+    const tracks = clip.tracks.filter((track) => trackTargetsBone(track.name, boneNames));
+    if (!tracks.length) throw new ThreeStadiumRuntimeError(`bone mask matched no tracks for clip: ${clip.name || 'unnamed'}`);
+    return new THREE.AnimationClip(
+      `${clip.name || 'clip'}:upper-body`,
+      clip.duration,
+      tracks,
+      clip.blendMode,
+    );
+  }
+
+  function defaultClipResolver({ model, action }) {
+    return (model.animations || []).find((clip) => clip.name === action) || null;
+  }
+
+  class ThreeStadiumRuntime {
+    constructor({
+      THREE,
+      CCDIKSolver,
+      clipResolver = defaultClipResolver,
+      upperBodyBones,
+      ikResolver,
+    } = {}) {
+      if (!THREE?.AnimationMixer || !THREE?.AnimationClip) {
+        throw new ThreeStadiumRuntimeError('THREE AnimationMixer and AnimationClip are required');
+      }
+      if (typeof CCDIKSolver !== 'function') throw new ThreeStadiumRuntimeError('CCDIKSolver constructor is required');
+      if (typeof clipResolver !== 'function') throw new ThreeStadiumRuntimeError('clipResolver must be a function');
+      if (typeof ikResolver !== 'function') throw new ThreeStadiumRuntimeError('ikResolver must be a function');
+      if (!Array.isArray(upperBodyBones) || !upperBodyBones.length) {
+        throw new ThreeStadiumRuntimeError('upperBodyBones must contain at least one bone name');
+      }
+      this.THREE = THREE;
+      this.CCDIKSolver = CCDIKSolver;
+      this.clipResolver = clipResolver;
+      this.upperBodyBones = [...upperBodyBones];
+      this.ikResolver = ikResolver;
+      this.mixer = null;
+      this.ikSolver = null;
+      this.actions = [];
+      this.plan = null;
+      this.model = null;
+    }
+
+    mount({ plan, model } = {}) {
+      if (!plan || plan.schema !== 'uinverse.stadium-performer-plan') {
+        throw new ThreeStadiumRuntimeError('stadium performer plan is required');
+      }
+      if (!model) throw new ThreeStadiumRuntimeError('loaded 3D model is required');
+      const baseLayer = plan.layers?.find(({ id }) => id === 'base-locomotion');
+      const upperLayer = plan.layers?.find(({ id }) => id === 'upper-body-performance');
+      if (!baseLayer || !upperLayer) throw new ThreeStadiumRuntimeError('plan requires base and upper-body layers');
+
+      const baseClip = this.clipResolver({ model, action: baseLayer.action, layer: baseLayer, plan });
+      const upperSourceClip = this.clipResolver({ model, action: upperLayer.action, layer: upperLayer, plan });
+      if (!baseClip) throw new ThreeStadiumRuntimeError(`missing animation clip: ${baseLayer.action}`);
+      if (!upperSourceClip) throw new ThreeStadiumRuntimeError(`missing animation clip: ${upperLayer.action}`);
+      const upperClip = maskAnimationClip(this.THREE, upperSourceClip, this.upperBodyBones);
+
+      this.model = model;
+      this.plan = plan;
+      this.mixer = new this.THREE.AnimationMixer(model);
+      const baseAction = this.mixer.clipAction(baseClip);
+      const upperAction = this.mixer.clipAction(upperClip);
+
+      const loopMode = this.THREE.LoopRepeat;
+      if (typeof baseAction.setLoop === 'function') baseAction.setLoop(loopMode, Infinity);
+      if (typeof upperAction.setLoop === 'function') upperAction.setLoop(loopMode, Infinity);
+      if (typeof baseAction.setEffectiveWeight === 'function') baseAction.setEffectiveWeight(1);
+      if (typeof upperAction.setEffectiveWeight === 'function') upperAction.setEffectiveWeight(1);
+      if (typeof baseAction.setEffectiveTimeScale === 'function') baseAction.setEffectiveTimeScale(0.5 + baseLayer.modifiers.speed);
+      if (typeof upperAction.setEffectiveTimeScale === 'function') upperAction.setEffectiveTimeScale(0.5 + upperLayer.modifiers.speed);
+      baseAction.play();
+      upperAction.play();
+      this.actions = [baseAction, upperAction];
+
+      const ikConfig = this.ikResolver({ model, plan, constraints: plan.constraints });
+      if (!ikConfig?.mesh || !Array.isArray(ikConfig.iks) || !ikConfig.iks.length) {
+        throw new ThreeStadiumRuntimeError('ikResolver must return { mesh, iks } with at least one IK chain');
+      }
+      this.ikSolver = new this.CCDIKSolver(ikConfig.mesh, ikConfig.iks);
+      return this;
+    }
+
+    update(deltaSeconds) {
+      if (!this.mixer || !this.ikSolver) throw new ThreeStadiumRuntimeError('runtime must be mounted before update');
+      const delta = Math.max(0, Math.min(Number(deltaSeconds) || 0, 0.05));
+      this.mixer.update(delta);
+      this.ikSolver.update(1);
+    }
+
+    dispose() {
+      if (this.mixer?.stopAllAction) this.mixer.stopAllAction();
+      this.actions = [];
+      this.ikSolver = null;
+      this.mixer = null;
+      this.plan = null;
+      this.model = null;
+    }
+  }
+
+  return {
+    ThreeStadiumRuntime,
+    ThreeStadiumRuntimeError,
+    maskAnimationClip,
+    trackTargetsBone,
+  };
+}));

--- a/tests/three-stadium-runtime.test.mjs
+++ b/tests/three-stadium-runtime.test.mjs
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { ThreeStadiumRuntime, ThreeStadiumRuntimeError, maskAnimationClip } = require('../src/character/three-stadium-runtime.js');
+
+const calls = [];
+class FakeClip {
+  constructor(name, duration, tracks, blendMode) {
+    this.name = name;
+    this.duration = duration;
+    this.tracks = tracks;
+    this.blendMode = blendMode;
+  }
+}
+class FakeAction {
+  constructor(clip) { this.clip = clip; }
+  setLoop(mode, count) { calls.push(['loop', this.clip.name, mode, count]); return this; }
+  setEffectiveWeight(value) { calls.push(['weight', this.clip.name, value]); return this; }
+  setEffectiveTimeScale(value) { calls.push(['speed', this.clip.name, value]); return this; }
+  play() { calls.push(['play', this.clip.name]); return this; }
+}
+class FakeMixer {
+  constructor(model) { this.model = model; calls.push(['mixer', model.id]); }
+  clipAction(clip) { return new FakeAction(clip); }
+  update(delta) { calls.push(['mixer-update', delta]); }
+  stopAllAction() { calls.push(['stop-all']); }
+}
+class FakeIK {
+  constructor(mesh, iks) { this.mesh = mesh; this.iks = iks; calls.push(['ik', iks.length]); }
+  update(blend) { calls.push(['ik-update', blend]); }
+}
+const THREE = { AnimationMixer: FakeMixer, AnimationClip: FakeClip, LoopRepeat: 'repeat' };
+
+const model = {
+  id: 'trombonist-model',
+  animations: [
+    new FakeClip('march', 1, [
+      { name: '.bones[Hips].position' },
+      { name: '.bones[Spine].quaternion' },
+      { name: '.bones[UpperArm_L].quaternion' },
+      { name: '.bones[UpperArm_R].quaternion' },
+      { name: '.bones[Foot_L].quaternion' },
+    ]),
+    new FakeClip('play-instrument', 1.5, [
+      { name: '.bones[Hips].position' },
+      { name: '.bones[Spine].quaternion' },
+      { name: '.bones[UpperArm_L].quaternion' },
+      { name: '.bones[UpperArm_R].quaternion' },
+      { name: '.bones[Hand_L].quaternion' },
+      { name: '.bones[Hand_R].quaternion' },
+      { name: '.bones[Foot_L].quaternion' },
+    ]),
+  ],
+};
+
+const plan = {
+  schema: 'uinverse.stadium-performer-plan',
+  characterId: 'stadium-trombonist',
+  layers: [
+    { id: 'base-locomotion', action: 'march', loop: true, modifiers: { speed: 0.6 } },
+    { id: 'upper-body-performance', action: 'play-instrument', loop: true, blend: 'upper-body', modifiers: { speed: 0.5 } },
+  ],
+  constraints: [
+    { target: 'left-hand', bone: 'Hand_L', itemId: 'instrument.trombone' },
+    { target: 'right-hand', bone: 'Hand_R', itemId: 'instrument.trombone' },
+  ],
+};
+
+function createRuntime() {
+  calls.length = 0;
+  return new ThreeStadiumRuntime({
+    THREE,
+    CCDIKSolver: FakeIK,
+    upperBodyBones: ['Spine', 'UpperArm_L', 'UpperArm_R', 'Hand_L', 'Hand_R'],
+    ikResolver: () => ({ mesh: { id: 'skinned-mesh' }, iks: [{ target: 1, effector: 2, links: [] }, { target: 3, effector: 4, links: [] }] }),
+  });
+}
+
+test('upper-body masking strips root and foot tracks from instrument clips', () => {
+  const masked = maskAnimationClip(THREE, model.animations[1], ['Spine', 'UpperArm_L', 'UpperArm_R', 'Hand_L', 'Hand_R']);
+  assert.equal(masked.name, 'play-instrument:upper-body');
+  assert.equal(masked.tracks.length, 5);
+  assert.equal(masked.tracks.some(({ name }) => name.includes('Hips')), false);
+  assert.equal(masked.tracks.some(({ name }) => name.includes('Foot_L')), false);
+});
+
+test('runtime mounts base and masked upper-body actions plus CCD IK', () => {
+  const runtime = createRuntime().mount({ plan, model });
+  assert.equal(runtime.actions.length, 2);
+  assert.equal(runtime.actions[0].clip.name, 'march');
+  assert.equal(runtime.actions[1].clip.name, 'play-instrument:upper-body');
+  assert.ok(calls.some((entry) => entry[0] === 'ik' && entry[1] === 2));
+});
+
+test('frame update applies animation before IK and clamps huge frame deltas', () => {
+  const runtime = createRuntime().mount({ plan, model });
+  calls.length = 0;
+  runtime.update(4);
+  assert.deepEqual(calls, [['mixer-update', 0.05], ['ik-update', 1]]);
+});
+
+test('dispose stops actions and releases runtime references', () => {
+  const runtime = createRuntime().mount({ plan, model });
+  calls.length = 0;
+  runtime.dispose();
+  assert.deepEqual(calls, [['stop-all']]);
+  assert.equal(runtime.mixer, null);
+  assert.equal(runtime.ikSolver, null);
+});
+
+test('runtime fails early for missing clips, masks, or IK configuration', () => {
+  assert.throws(() => new ThreeStadiumRuntime({ THREE, CCDIKSolver: FakeIK, upperBodyBones: [], ikResolver() {} }), ThreeStadiumRuntimeError);
+  const missingClip = createRuntime();
+  assert.throws(() => missingClip.mount({ plan: { ...plan, layers: [{ ...plan.layers[0], action: 'moonwalk' }, plan.layers[1]] }, model }), /missing animation clip/);
+  const noIk = new ThreeStadiumRuntime({ THREE, CCDIKSolver: FakeIK, upperBodyBones: ['Spine'], ikResolver: () => ({ mesh: {}, iks: [] }) });
+  assert.throws(() => noIk.mount({ plan, model }), /ikResolver/);
+});


### PR DESCRIPTION
## What changed

- Adds a concrete Three.js-facing runtime seam for Stadium performer plans without importing Three into upstream character contracts.
- Accepts injected `THREE` and `CCDIKSolver` dependencies so the current static app does not acquire a production engine dependency merely to prove the slice.
- Resolves semantic Stadium layers to actual animation clips through an injected clip resolver.
- Creates a full-body march action plus a derived upper-body instrument clip by filtering keyframe tracks against an explicit bone mask.
- Delegates model-specific CCD chain construction to an injected IK resolver.
- Applies animation first and IK second each frame, clamps oversized frame deltas, and disposes mixer state cleanly.
- Adds five focused runtime tests with fake Three primitives to verify masking, layering, IK creation/update ordering, disposal, and failure modes.
- Records the Three.js vs PlayCanvas vs Babylon.js decision and the exact point where a real Three dependency should be introduced: a tiny visual GLTF fixture.

## Why Three.js first

The marching-trombone slice needs skeletal clip playback, simultaneous weighted actions, upper-body masking, and two-hand IK. Three.js supplies the compact mixer/action model and an official `CCDIKSolver` addon. Upper-body masking is a small adapter concern because clips are composed of named keyframe tracks.

PlayCanvas remains attractive for its first-class layer masks; Babylon remains attractive for its built-in IK controller. Both can remain future implementations behind the same engine-neutral StadiumPerformerPlan.

## Dependency

Stacked on #59, which is stacked on #58 and #56.

## Next proving step

Create a tiny GLTF marching-trombonist fixture with named `march` and `play-instrument` clips, explicit IK targets, and a trombone prop. Mount this adapter against the real Three.js classes in a visual fixture. Only then add Three.js as a production/dev runtime dependency if the real slice earns it.